### PR TITLE
Cleaned up public certificates logic

### DIFF
--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -238,7 +238,7 @@ class WooThemes_Sensei_Certificates {
 
 		$fields['certificates_public_viewable'] = array(
 			'name' 			=> __( 'Public Certificate', 'sensei-certificates' ),
-			'description' 	=> __( 'Allow the Learner to share their Certificate with the public.', 'sensei-certificates' ),
+			'description' 	=> __( 'Allow the Learner to share their Certificate with the public. (The learner will have to enable this in their profile by going to mysite.com/learner/{learner_username})', 'sensei-certificates' ),
 			'type' 			=> 'checkbox',
 			'default' 		=> true,
 			'section' 		=> 'certificate-settings'


### PR DESCRIPTION
Fixed #76. Firstly, we want both the `Allow the Learner to share their Certificate with the public` global setting, and the `Allow my Certificates to be publicly viewed` user setting to be `true` before we show a certificate to the public. 

Thus, we no longer show the `Allow my Certificates to be publicly viewed` checkbox on the user's learner profile unless `$woothemes_sensei->settings->settings['certificates_public_viewable']` is `true`, since the global setting should override the user setting. Having the user setting displayed when the global setting is disabled is unintuitive.

Also added a filter to force all certificates to be public, as it's a good have a option that a developer can use to sidestep both the global and user public certificate settings.
