### PR TITLE
Fix the selected admin menu item when editing a certificate template

### DIFF
--- a/admin/woothemes-sensei-certificate-templates-admin-init.php
+++ b/admin/woothemes-sensei-certificate-templates-admin-init.php
@@ -39,26 +39,9 @@ include_once( 'post-types/certificate_templates.php' );
 /**
  * Actions and Filters
  */
-add_action( 'admin_head', 'sensei_certificate_template_admin_menu_highlight' );
 add_action( 'admin_init', 'sensei_certificate_template_admin_init' );
 add_action( 'admin_enqueue_scripts', 'sensei_certificate_template_admin_enqueue_scripts' );
 add_filter( 'post_updated_messages', 'sensei_certificate_template_item_updated_messages' );
-
-
-/**
- * Highlight the correct top level admin menu item for the certificate post type add screen
- *
- * @since 1.0.0
- */
-function sensei_certificate_template_admin_menu_highlight() {
-	global $menu, $submenu, $parent_file, $submenu_file, $self, $post_type, $taxonomy;
-
-	if ( isset( $post_type ) && 'certificate_template' == $post_type ) {
-		$submenu_file = 'edit.php?post_type=' . $post_type;
-		$parent_file  = 'sensei';
-	} // End If Statement
-
-} // End sensei_certificate_template_admin_menu_highlight()
 
 
 /**


### PR DESCRIPTION
Currently, when you are editing a certificate template, the selected (and opened) top-level menu item in the left-hand WP admin menu is "Sensei" rather than "Certificates". I'm guessing this was needed in an earlier version of the plugin, but since "Certificate Templates" is now located under the "Certificates" top-level menu item this code is no longer needed.
