### PR TITLE
Certificate data field enhancements

### DIFF
--- a/admin/post-types/writepanels/writepanel-certificate_data.php
+++ b/admin/post-types/writepanels/writepanel-certificate_data.php
@@ -85,176 +85,45 @@ function certificate_template_data_meta_box( $post ) {
 					) );
 				echo '</div>';
 
-				// Heading
-				echo '<div class="options_group">';
-					certificate_templates_wp_position_picker( array(
-						'id'          => 'certificate_heading_pos',
-						'label'       => __( 'Heading Position', 'sensei-certificates' ),
-						'value'       => implode( ',', $woothemes_sensei_certificate_templates->get_field_position( 'certificate_heading' ) ),
-						'description' => __( 'Optional position of the Certificate Heading', 'sensei-certificates' ),
-					) );
-					certificates_wp_hidden_input( array(
-						'id'    => '_certificate_heading_pos',
-						'class' => 'field_pos',
-						'value' => implode( ',', $woothemes_sensei_certificate_templates->get_field_position( 'certificate_heading' ) ),
-					) );
-					certificate_templates_wp_font_select( array(
-						'id'      => '_certificate_heading',
-						'label'   => __( 'Font', 'sensei-certificates' ),
-						'options' => $available_fonts,
-					) );
-					certificates_wp_text_input( array(
-						'id'    => '_certificate_heading_font_color',
-						'label' => __( 'Font color', 'sensei-certificates' ),
-						'value' => isset( $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_heading']['font']['color'] ) ? $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_heading']['font']['color'] : '',
-						'class' => 'colorpick',
-					) );
-					certificates_wp_text_input( array(
-						'class'       => 'medium',
-						'id'          => '_certificate_heading_text',
-						'label'       => __( 'Heading Text', 'sensei-certificates' ),
-						'description' => __( 'Text to display in the heading.', 'sensei-certificates' ),
-						'placeholder' => __( 'Certificate of Completion', 'sensei-certificates' ),
-						'value'       => isset( $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_heading']['text'] ) ? $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_heading']['text'] : '',
-					) );
-				echo '</div>';
+				// Data fields
+				$data_fields = sensei_get_certificate_data_fields();
+				foreach ( $data_fields as $field_key => $field_info ) {
 
-				// Message
-				echo '<div class="options_group">';
-					certificate_templates_wp_position_picker( array(
-						'id'          => 'certificate_message_pos',
-						'label'       => __( 'Message Position', 'sensei-certificates' ),
-						'value'       => implode( ',', $woothemes_sensei_certificate_templates->get_field_position( 'certificate_message' ) ),
-						'description' => __( 'Optional position of the Certificate Message', 'sensei-certificates' ),
-					) );
-					certificates_wp_hidden_input( array(
-						'id'    => '_certificate_message_pos',
-						'class' => 'field_pos',
-						'value' => implode( ',', $woothemes_sensei_certificate_templates->get_field_position( 'certificate_message' ) )
-					) );
-					certificate_templates_wp_font_select( array(
-						'id'      => '_certificate_message',
-						'label'   => __( 'Font', 'sensei-certificates' ),
-						'options' => $available_fonts,
-					) );
-					certificates_wp_text_input( array(
-						'id'    => '_certificate_message_font_color',
-						'label' => __( 'Font color', 'sensei-certificates' ),
-						'value' => isset( $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_message']['font']['color'] ) ? $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_message']['font']['color'] : '',
-						'class' => 'colorpick',
-					) );
-					certificates_wp_textarea_input( array(
-						'class'       => 'medium',
-						'id'          => '_certificate_message_text',
-						'label'       => __( 'Message Text', 'sensei-certificates' ),
-						'description' => __( 'Text to display in the message area.', 'sensei-certificates' ),
-						'placeholder' => __( 'This is to certify that {{learner}} has completed the course', 'sensei-certificates' ),
-						'value'       => isset( $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_message']['text'] ) ? $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_message']['text'] : '',
-					) );
-				echo '</div>';
+					echo '<div class="options_group">';
+						certificate_templates_wp_position_picker( array(
+							'id'          => "certificate_{$field_key}_pos",
+							'label'       => $field_info['position_label'],
+							'value'       => implode( ',', $woothemes_sensei_certificate_templates->get_field_position( "certificate_$field_key" ) ),
+							'description' => $field_info['position_description'],
+						) );
+						certificates_wp_hidden_input( array(
+							'id'    => "_certificate_{$field_key}_pos",
+							'class' => 'field_pos',
+							'value' => implode( ',', $woothemes_sensei_certificate_templates->get_field_position( "certificate_$field_key" ) ),
+						) );
+						certificate_templates_wp_font_select( array(
+							'id'      => "_certificate_$field_key",
+							'label'   => __( 'Font', 'sensei-certificates' ),
+							'options' => $available_fonts,
+						) );
+						certificates_wp_text_input( array(
+							'id'    => "_certificate_{$field_key}_font_color",
+							'label' => __( 'Font color', 'sensei-certificates' ),
+							'value' => isset( $woothemes_sensei_certificate_templates->certificate_template_fields["certificate_$field_key"]['font']['color'] ) ? $woothemes_sensei_certificate_templates->certificate_template_fields["certificate_$field_key"]['font']['color'] : '',
+							'class' => 'colorpick',
+						) );
 
-				// Certificate course position
-				echo '<div class="options_group">';
-					certificate_templates_wp_position_picker( array(
-						'id'          => 'certificate_course_pos',
-						'label'       => __( 'Course Position', 'sensei-certificates' ),
-						'value'       => implode( ',', $woothemes_sensei_certificate_templates->get_field_position( 'certificate_course' ) ),
-						'description' => __( 'Optional position of the Course Name', 'sensei-certificates' ),
-					) );
-					certificates_wp_hidden_input( array(
-						'id'    => '_certificate_course_pos',
-						'class' => 'field_pos',
-						'value' => implode( ',', $woothemes_sensei_certificate_templates->get_field_position( 'certificate_course' ) ),
-					) );
-					certificate_templates_wp_font_select( array(
-						'id'      => '_certificate_course',
-						'label'   => __( 'Font', 'sensei-certificates' ),
-						'options' => $available_fonts,
-					) );
-					certificates_wp_text_input( array(
-						'id'    => '_certificate_course_font_color',
-						'label' => __( 'Font color', 'sensei-certificates' ),
-						'value' => isset( $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_course']['font']['color'] ) ? $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_course']['font']['color'] : '',
-						'class' => 'colorpick',
-					) );
-					certificates_wp_text_input( array(
-						'class'       => 'medium',
-						'id'          => '_certificate_course_text',
-						'label'       => __( 'Course Text', 'sensei-certificates' ),
-						'description' => __( 'Text to display in the course area.', 'sensei-certificates' ),
-						'placeholder' => __( '{{course_title}}', 'sensei-certificates' ),
-						'value'       => isset( $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_course']['text'] ) ? $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_course']['text'] : '',
-					) );
-				echo '</div>';
-
-				// Certificate complete position
-				echo '<div class="options_group">';
-					certificate_templates_wp_position_picker( array(
-						'id'          => 'certificate_completion_pos',
-						'label'       => __( 'Completion Date Position', 'sensei-certificates' ),
-						'value'       => implode( ',', $woothemes_sensei_certificate_templates->get_field_position( 'certificate_completion' ) ),
-						'description' => __( 'Optional position of the Course Completion date', 'sensei-certificates' ),
-					) );
-					certificates_wp_hidden_input( array(
-						'id' => '_certificate_completion_pos',
-						'class' => 'field_pos',
-						'value' => implode( ',', $woothemes_sensei_certificate_templates->get_field_position( 'certificate_completion' ) ),
-					) );
-					certificate_templates_wp_font_select( array(
-						'id'      => '_certificate_completion',
-						'label'   => __( 'Font', 'sensei-certificates' ),
-						'options' => $available_fonts,
-					) );
-					certificates_wp_text_input( array(
-						'id'    => '_certificate_completion_font_color',
-						'label' => __( 'Font color', 'sensei-certificates' ),
-						'value' => isset( $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_completion']['font']['color'] ) ? $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_completion']['font']['color'] : '',
-						'class' => 'colorpick',
-					) );
-					certificates_wp_text_input( array(
-						'class'       => 'medium',
-						'id'          => '_certificate_completion_text',
-						'label'       => __( 'Completion Date Text', 'sensei-certificates' ),
-						'description' => __( 'Text to display in the course completion date area.', 'sensei-certificates' ),
-						'placeholder' => __( '{{completion_date}}', 'sensei-certificates' ),
-						'value'       => isset( $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_completion']['text'] ) ? $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_completion']['text'] : '',
-					) );
-				echo '</div>';
-
-				// Certificate place position
-				echo '<div class="options_group">';
-					certificate_templates_wp_position_picker( array(
-						'id'          => 'certificate_place_pos',
-						'label'       => __( 'Place Position', 'sensei-certificates' ),
-						'value'       => implode( ',', $woothemes_sensei_certificate_templates->get_field_position( 'certificate_place' ) ),
-						'description' => __( 'Optional position of the place of Certification.', 'sensei-certificates' ),
-					) );
-					certificates_wp_hidden_input( array(
-						'id'    => '_certificate_place_pos',
-						'class' => 'field_pos',
-						'value' => implode( ',', $woothemes_sensei_certificate_templates->get_field_position( 'certificate_place' ) ),
-					) );
-					certificate_templates_wp_font_select( array(
-						'id'      => '_certificate_place',
-						'label'   => __( 'Font', 'sensei-certificates' ),
-						'options' => $available_fonts,
-					) );
-					certificates_wp_text_input( array(
-						'id'    => '_certificate_place_font_color',
-						'label' => __( 'Font color', 'sensei-certificates' ),
-						'value' => isset( $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_place']['font']['color'] ) ? $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_place']['font']['color'] : '',
-						'class' => 'colorpick',
-					) );
-					certificates_wp_text_input( array(
-						'class'       => 'medium',
-						'id'          => '_certificate_place_text',
-						'label'       => __( 'Course Place Text', 'sensei-certificates' ),
-						'description' => __( 'Text to display in the course place area.', 'sensei-certificates' ),
-						'placeholder' => __( '{{course_place}}', 'sensei-certificates' ),
-						'value'       => isset( $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_place']['text'] ) ? $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_place']['text'] : '',
-					) );
-				echo '</div>';
-
+						$text_function = ( $field_info['type'] == 'textarea' ) ? 'certificates_wp_textarea_input' : 'certificates_wp_text_input';
+						$text_function( array(
+							'class'       => 'medium',
+							'id'          => "_certificate_{$field_key}_text",
+							'label'       => $field_info['text_label'],
+							'description' => $field_info['text_description'],
+							'placeholder' => $field_info['text_placeholder'],
+							'value'       => isset( $woothemes_sensei_certificate_templates->certificate_template_fields["certificate_$field_key"]['text'] ) ? $woothemes_sensei_certificate_templates->certificate_template_fields["certificate_$field_key"]['text'] : '',
+						) );
+					echo '</div>';
+				}
 			?>
 		</div>
 	</div>
@@ -288,7 +157,10 @@ function certificate_templates_process_meta( $post_id, $post ) {
 	// original sizes: default 11, product name 16, sku 8
 	// create the certificate template fields data structure
 	$fields = array();
-	foreach ( array( '_certificate_heading', '_certificate_message', '_certificate_course', '_certificate_completion', '_certificate_place' ) as $i => $field_name ) {
+	$data_fields = sensei_get_certificate_data_fields();
+	foreach ( array_keys($data_fields) as $i => $field_key ) {
+
+		$field_name = '_certificate_' . $field_key;
 
 		// set the field defaults
 		$field = array(

--- a/classes/class-woothemes-sensei-certificate-templates.php
+++ b/classes/class-woothemes-sensei-certificate-templates.php
@@ -451,62 +451,31 @@ class WooThemes_Sensei_Certificate_Templates {
 			$date_format = apply_filters( 'sensei_certificate_date_format', '%Y %B %e' );
 			$date = strftime ( $date_format, strtotime( $course_end_date ) );
 		}
-		
-		$certificate_heading = __( 'Certificate of Completion', 'sensei-certificates' ); // Certificate of Completion
-		if ( isset( $this->certificate_template_fields['certificate_heading']['text'] ) && '' != $this->certificate_template_fields['certificate_heading']['text'] ) {
 
-			$certificate_heading = $this->certificate_template_fields['certificate_heading']['text'];
-			$certificate_heading = str_replace( array( '{{learner}}', '{{course_title}}', '{{completion_date}}', '{{course_place}}'  ), array( $student_name, $course['post_title'], $date, get_bloginfo( 'name' ) ) , $certificate_heading );
+		// Data fields
+		$data_fields = sensei_get_certificate_data_fields();
+		foreach ( $data_fields as $field_key => $field_info ) {
 
-		} // End If Statement
+			$meta_key = 'certificate_' . $field_key;
+			// Get the default field value
+			$field_value = $field_info['text_placeholder'];
+			if ( isset( $this->certificate_template_fields[$meta_key]['text'] ) && '' != $this->certificate_template_fields[$meta_key]['text'] ) {
 
-		$certificate_message = __( 'This is to certify that', 'sensei-certificates' ) . " \r\n\r\n" . $student_name . " \r\n\r\n" . __( 'has completed the course', 'sensei-certificates' ); // This is to certify that {{learner}} has completed the course
-		if ( isset( $this->certificate_template_fields['certificate_message']['text'] ) && '' != $this->certificate_template_fields['certificate_message']['text'] ) {
+				$field_value = $this->certificate_template_fields[$meta_key]['text'];
+			} // End If Statement
 
-			$certificate_message = $this->certificate_template_fields['certificate_message']['text'];
-			$certificate_message = str_replace( array( '{{learner}}', '{{course_title}}', '{{completion_date}}', '{{course_place}}'  ), array( $student_name, $course['post_title'], $date, get_bloginfo( 'name' ) ) , $certificate_message );
-
-		} // End If Statement
-
-		$certificate_course = $course['post_title']; // {{course_title}}
-		if ( isset( $this->certificate_template_fields['certificate_course']['text'] ) && '' != $this->certificate_template_fields['certificate_course']['text'] ) {
-
-			$certificate_course = $this->certificate_template_fields['certificate_course']['text'];
-			$certificate_course = str_replace( array( '{{learner}}', '{{course_title}}', '{{completion_date}}', '{{course_place}}'  ), array( $student_name, $course['post_title'], $date, get_bloginfo( 'name' ) ) , $certificate_course );
-
-		} // End If Statement
-
-		$certificate_completion = $date; // {{completion_date}}
-		if ( isset( $this->certificate_template_fields['certificate_completion']['text'] ) && '' != $this->certificate_template_fields['certificate_completion']['text'] ) {
-
-			$certificate_completion = $this->certificate_template_fields['certificate_completion']['text'];
-			$certificate_completion = str_replace( array( '{{learner}}', '{{course_title}}', '{{completion_date}}', '{{course_place}}'  ), array( $student_name, $course['post_title'], $date, get_bloginfo( 'name' ) ) , $certificate_completion );
-
-		} // End If Statement
-
-		$certificate_place = sprintf( __( 'At %s', 'sensei-certificates' ), get_bloginfo( 'name' ) ); // At {{course_place}}
-		if ( isset( $this->certificate_template_fields['certificate_place']['text'] ) && '' != $this->certificate_template_fields['certificate_place']['text'] ) {
-
-			$certificate_place = $this->certificate_template_fields['certificate_place']['text'];
-			$certificate_place = str_replace( array( '{{learner}}', '{{course_title}}', '{{completion_date}}', '{{course_place}}'  ), array( $student_name, $course['post_title'], $date, get_bloginfo( 'name' ) ) , $certificate_place );
-
-		} // End If Statement
-
-		$output_fields = array(	'certificate_heading' 		=> 'text_field',
-								'certificate_message' 		=> 'textarea_field',
-								'certificate_course'		=> 'text_field',
-								'certificate_completion' 	=> 'text_field',
-								'certificate_place' 		=> 'text_field',
-							 );
-
-		foreach ( $output_fields as $meta_key => $function_name ) {
+			// Replace the template tags
+			$field_value = str_replace( array( '{{learner}}', '{{course_title}}', '{{completion_date}}', '{{course_place}}'  ), array( $student_name, $course['post_title'], $date, get_bloginfo( 'name' ) ) , $field_value );
 
 			// Check if the field has a set position
 			if ( isset( $this->certificate_template_fields[$meta_key]['position']['x1'] ) ) {
 
+				// Write the value to the PDF
+				$function_name = ( $field_info['type'] == 'textarea' ) ? 'textarea_field' : 'text_field';
+
 				$font_settings = $this->get_certificate_font_settings( $meta_key );
 
-				call_user_func_array(array($this, $function_name), array( $fpdf, $$meta_key, $show_border, array( $this->certificate_template_fields[$meta_key]['position']['x1'], $this->certificate_template_fields[$meta_key]['position']['y1'], $this->certificate_template_fields[$meta_key]['position']['width'], $this->certificate_template_fields[$meta_key]['position']['height'] ), $font_settings ));
+				call_user_func_array(array($this, $function_name), array( $fpdf, $field_value, $show_border, array( $this->certificate_template_fields[$meta_key]['position']['x1'], $this->certificate_template_fields[$meta_key]['position']['y1'], $this->certificate_template_fields[$meta_key]['position']['width'], $this->certificate_template_fields[$meta_key]['position']['height'] ), $font_settings ));
 
 			} // End If Statement
 

--- a/classes/class-woothemes-sensei-certificate-templates.php
+++ b/classes/class-woothemes-sensei-certificate-templates.php
@@ -361,7 +361,7 @@ class WooThemes_Sensei_Certificate_Templates {
 	 */
 	public function generate_pdf( $path = '' ) {
 
-		global $current_user, $post;
+		global $post;
 
 		// include the pdf library
 		$root_dir = dirname( __FILE__ ) . DIRECTORY_SEPARATOR;
@@ -405,21 +405,6 @@ class WooThemes_Sensei_Certificate_Templates {
 		//  display that prior to the translation
 		$show_border = 0;
 
-		// Get Student Data
-		wp_get_current_user();
-		$fname = $current_user->first_name;
-		$lname = $current_user->last_name;
-		$student_name = $current_user->display_name;
-
-		if ( '' != $fname && '' != $lname ) {
-			$student_name = $fname . ' ' . $lname;
-		}
-
-		// Get Course Data
-		$course = array();
-		$course['post_title'] = __( 'Course Title', 'sensei-certificates' );
-		$course_end_date = date('Y-m-d');
-
 		// Get the certificate template
 		$certificate_template_custom_fields = get_post_custom( $post->ID );
 
@@ -441,17 +426,6 @@ class WooThemes_Sensei_Certificate_Templates {
 
 		} // End For Loop
 
-		// Set default fonts
-		setlocale(LC_TIME, get_locale() );
-
-		if( false !== strpos( get_locale(), 'en' ) ) {
-			$date_format = apply_filters( 'sensei_certificate_date_format', 'jS F Y' );
-			$date = date( $date_format, strtotime( $course_end_date ) );
-		} else {
-			$date_format = apply_filters( 'sensei_certificate_date_format', '%Y %B %e' );
-			$date = strftime ( $date_format, strtotime( $course_end_date ) );
-		}
-
 		// Data fields
 		$data_fields = sensei_get_certificate_data_fields();
 		foreach ( $data_fields as $field_key => $field_info ) {
@@ -465,7 +439,7 @@ class WooThemes_Sensei_Certificate_Templates {
 			} // End If Statement
 
 			// Replace the template tags
-			$field_value = str_replace( array( '{{learner}}', '{{course_title}}', '{{completion_date}}', '{{course_place}}'  ), array( $student_name, $course['post_title'], $date, get_bloginfo( 'name' ) ) , $field_value );
+			$field_value = apply_filters( 'sensei_certificate_data_field_value', $field_value, $field_key, true, null, null );
 
 			// Check if the field has a set position
 			if ( isset( $this->certificate_template_fields[$meta_key]['position']['x1'] ) ) {

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -556,60 +556,31 @@ class WooThemes_Sensei_Certificates {
 				$date = strftime ( $date_format, strtotime( $course_end_date ) );
 			}
 
-			$certificate_heading = __( 'Certificate of Completion', 'sensei-certificates' ); // Certificate of Completion
-			if ( isset( $this->certificate_template_fields['certificate_heading']['text'] ) && '' != $this->certificate_template_fields['certificate_heading']['text'] ) {
+			// Data fields
+			$data_fields = sensei_get_certificate_data_fields();
+			foreach ( $data_fields as $field_key => $field_info ) {
 
-				$certificate_heading = $this->certificate_template_fields['certificate_heading']['text'];
-				$certificate_heading = str_replace( array( '{{learner}}', '{{course_title}}', '{{completion_date}}', '{{course_place}}'  ), array( $student_name, $course->post_title, $date, get_bloginfo( 'name' ) ) , $certificate_heading );
-			} // End If Statement
+				$meta_key = 'certificate_' . $field_key;
 
-			$certificate_message = __( 'This is to certify that', 'sensei-certificates' ) . " \r\n\r\n" . $student_name . " \r\n\r\n" . __( 'has completed the course', 'sensei-certificates' ); // This is to certify that {{learner}} has completed the course
-			if ( isset( $this->certificate_template_fields['certificate_message']['text'] ) && '' != $this->certificate_template_fields['certificate_message']['text'] ) {
+				// Get the default field value
+				$field_value = $field_info['text_placeholder'];
+				if ( isset( $this->certificate_template_fields[$meta_key]['text'] ) && '' != $this->certificate_template_fields[$meta_key]['text'] ) {
 
-				$certificate_message = $this->certificate_template_fields['certificate_message']['text'];
-				$certificate_message = str_replace( array( '{{learner}}', '{{course_title}}', '{{completion_date}}', '{{course_place}}'  ), array( $student_name, $course->post_title, $date, get_bloginfo( 'name' ) ) , $certificate_message );
+					$field_value = $this->certificate_template_fields[$meta_key]['text'];
+				} // End If Statement
 
-			} // End If Statement
-
-			$certificate_course = $course->post_title; // {{course_title}}
-			if ( isset( $this->certificate_template_fields['certificate_course']['text'] ) && '' != $this->certificate_template_fields['certificate_course']['text'] ) {
-
-				$certificate_course = $this->certificate_template_fields['certificate_course']['text'];
-				$certificate_course = str_replace( array( '{{learner}}', '{{course_title}}', '{{completion_date}}', '{{course_place}}'  ), array( $student_name, $course->post_title, $date, get_bloginfo( 'name' ) ) , $certificate_course );
-
-			} // End If Statement
-
-			$certificate_completion = $date; // {{completion_date}}
-			if ( isset( $this->certificate_template_fields['certificate_completion']['text'] ) && '' != $this->certificate_template_fields['certificate_completion']['text'] ) {
-
-				$certificate_completion = $this->certificate_template_fields['certificate_completion']['text'];
-				$certificate_completion = str_replace( array( '{{learner}}', '{{course_title}}', '{{completion_date}}', '{{course_place}}'  ), array( $student_name, $course->post_title, $date, get_bloginfo( 'name' ) ) , $certificate_completion );
-
-			} // End If Statement
-
-			$certificate_place = sprintf( __( 'At %s', 'sensei-certificates' ), get_bloginfo( 'name' ) ); // At {{course_place}}
-			if ( isset( $this->certificate_template_fields['certificate_place']['text'] ) && '' != $this->certificate_template_fields['certificate_place']['text'] ) {
-
-				$certificate_place = $this->certificate_template_fields['certificate_place']['text'];
-				$certificate_place = str_replace( array( '{{learner}}', '{{course_title}}', '{{completion_date}}', '{{course_place}}'  ), array( $student_name, $course->post_title, $date, get_bloginfo( 'name' ) ) , $certificate_place );
-
-			} // End If Statement
-
-			$output_fields = array(	'certificate_heading' 		=> 'text_field',
-									'certificate_message' 		=> 'textarea_field',
-									'certificate_course'		=> 'text_field',
-									'certificate_completion' 	=> 'text_field',
-									'certificate_place' 		=> 'text_field',
-								 );
-
-			foreach ( $output_fields as $meta_key => $function_name ) {
+				// Replace the template tags
+				$field_value = str_replace( array( '{{learner}}', '{{course_title}}', '{{completion_date}}', '{{course_place}}'  ), array( $student_name, $course->post_title, $date, get_bloginfo( 'name' ) ) , $field_value );
 
 				// Check if the field has a set position
 				if ( isset( $this->certificate_template_fields[$meta_key]['position']['x1'] ) ) {
 
+					// Write the value to the PDF
+					$function_name = ( $field_info['type'] == 'textarea' ) ? 'textarea_field' : 'text_field';
+
 					$font_settings = $this->get_certificate_font_settings( $meta_key );
 
-					call_user_func_array(array($pdf_certificate, $function_name), array( $fpdf, $$meta_key, $show_border, array( $this->certificate_template_fields[$meta_key]['position']['x1'], $this->certificate_template_fields[$meta_key]['position']['y1'], $this->certificate_template_fields[$meta_key]['position']['width'], $this->certificate_template_fields[$meta_key]['position']['height'] ), $font_settings ));
+					call_user_func_array(array($pdf_certificate, $function_name), array( $fpdf, $field_value, $show_border, array( $this->certificate_template_fields[$meta_key]['position']['x1'], $this->certificate_template_fields[$meta_key]['position']['y1'], $this->certificate_template_fields[$meta_key]['position']['width'], $this->certificate_template_fields[$meta_key]['position']['height'] ), $font_settings ));
 
 				} // End If Statement
 

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -24,6 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
  * - generate_certificate_number()
  * - can_view_certificate()
  * - download_certificate()
+ * - replace_data_field_template_tags()
  * - certificate_text()
  * - certificate_backgroudn()
  * - get_certificate_font_settings()
@@ -123,6 +124,8 @@ class WooThemes_Sensei_Certificates {
 		add_action( 'sensei_user_course_end', array( $this, 'generate_certificate_number' ), 10, 2 );
 		// Background Image to display on certificate
 		add_action( 'sensei_certificates_set_background_image', array( $this, 'certificate_background' ), 10, 1 );
+		// Certificate data field tag replacement
+		add_filter( 'sensei_certificate_data_field_value', array( $this, 'replace_data_field_template_tags'), 10, 5 );
 		// Text to display on certificate
 		add_action( 'sensei_certificates_before_pdf_output', array( $this, 'certificate_text' ), 10, 2 );
 
@@ -464,6 +467,58 @@ class WooThemes_Sensei_Certificates {
 
 	} // End generate_certificate()
 
+	/**
+	 * Replace template tags on certificate data fields.
+	 *
+	 * @access public
+	 * @since  x.x.x
+	 * @return string
+	 */
+	public function replace_data_field_template_tags($field_value, $field_key, $is_preview, $student, $course)
+	{
+		// Prepare data
+		if ($is_preview) {
+			$student = wp_get_current_user();
+			$course_title = __( 'Course Title', 'sensei-certificates' );
+			$course_end_date = date('Y-m-d');
+		}
+		else {
+			$course_title = $course->post_title;
+			$course_end = Sensei_Utils::sensei_check_for_activity( array( 'post_id' => $course->ID, 'user_id' => $user->ID, 'type' => 'sensei_course_status' ), true );
+			$course_end_date = $course_end->comment_date;
+		}
+
+		// Get student name
+		$student_name = $student->display_name;
+		$fname = $student->first_name;
+		$lname = $student->last_name;
+
+		if ( '' != $fname && '' != $lname ) {
+			$student_name = $fname . ' ' . $lname;
+		}
+
+		// Get end date
+		setlocale(LC_TIME, get_locale() );
+
+		if( false !== strpos( get_locale(), 'en' ) ) {
+			$date_format = apply_filters( 'sensei_certificate_date_format', 'jS F Y' );
+			$date = date( $date_format, strtotime( $course_end_date ) );
+		} else {
+			$date_format = apply_filters( 'sensei_certificate_date_format', '%Y %B %e' );
+			$date = strftime ( $date_format, strtotime( $course_end_date ) );
+		}
+
+		$replacement_values = array(
+			'{{learner}}' => $student_name,
+			'{{course_title}}' => $course_title,
+			'{{completion_date}}' => $completion_date,
+			'{{course_place}}' => get_bloginfo('name'),
+		);
+
+		$field_value = str_replace( array_keys( $replacement_values ), array_values( $replacement_values ), $field_value );
+
+		return $field_value;
+	}
 
 	/**
 	 * Add text to the certificate
@@ -501,20 +556,11 @@ class WooThemes_Sensei_Certificates {
 			// Get Student Data
 			$user_id = get_post_meta( $certificate_id, 'learner_id', true );
 			$student = get_userdata( $user_id );
-			$student_name = $student->display_name;
-			$fname = $student->first_name;
-			$lname = $student->last_name;
-
-			if ( '' != $fname && '' != $lname ) {
-				$student_name = $fname . ' ' . $lname;
-			}
 
 			// Get Course Data
 			$course_id = get_post_meta( $certificate_id, 'course_id', true );
 			$course = Sensei()->course->course_query( -1, 'usercourses', $course_id );
 			$course = $course[0];
-			$course_end = Sensei_Utils::sensei_check_for_activity( array( 'post_id' => intval( $course_id ), 'user_id' => intval( $user_id ), 'type' => 'sensei_course_status' ), true );
-			$course_end_date = $course_end->comment_date;
 
 			// Get the certificate template
 			$certificate_template_id = get_post_meta( $course_id, '_course_certificate_template', true );
@@ -545,17 +591,6 @@ class WooThemes_Sensei_Certificates {
 			if ( isset( $this->certificate_font_family ) && '' != $this->certificate_font_family ) { $pdf_certificate->certificate_pdf_data['font_family'] = $this->certificate_font_family; }
 			if ( isset( $this->certificate_font_style ) && '' != $this->certificate_font_style ) { $pdf_certificate->certificate_pdf_data['font_style'] = $this->certificate_font_style; }
 
-			// Set default fonts
-			setlocale(LC_TIME, get_locale() );
-
-			if( false !== strpos( get_locale(), 'en' ) ) {
-				$date_format = apply_filters( 'sensei_certificate_date_format', 'jS F Y' );
-				$date = date( $date_format, strtotime( $course_end_date ) );
-			} else {
-				$date_format = apply_filters( 'sensei_certificate_date_format', '%Y %B %e' );
-				$date = strftime ( $date_format, strtotime( $course_end_date ) );
-			}
-
 			// Data fields
 			$data_fields = sensei_get_certificate_data_fields();
 			foreach ( $data_fields as $field_key => $field_info ) {
@@ -570,7 +605,7 @@ class WooThemes_Sensei_Certificates {
 				} // End If Statement
 
 				// Replace the template tags
-				$field_value = str_replace( array( '{{learner}}', '{{course_title}}', '{{completion_date}}', '{{course_place}}'  ), array( $student_name, $course->post_title, $date, get_bloginfo( 'name' ) ) , $field_value );
+				$field_value = apply_filters( 'sensei_certificate_data_field_value', $field_value, $field_key, false, $student, $course );
 
 				// Check if the field has a set position
 				if ( isset( $this->certificate_template_fields[$meta_key]['position']['x1'] ) ) {

--- a/woothemes-sensei-certificates.php
+++ b/woothemes-sensei-certificates.php
@@ -21,6 +21,7 @@
  * - sensei_certificates_updates_list()
  * - sensei_update_users_certificate_data()
  * - sensei_create_master_certificate_template()
+ * - sensei_get_certificate_data_fields()
  * - is_sensei_active()
  */
 
@@ -416,6 +417,58 @@ function sensei_create_master_certificate_template() {
 	} // End If Statement
 
 } // End sensei_create_master_certificate_template()
+
+/**
+ * sensei_get_certificate_data_fields gets the data fields that are applied to each certificate.
+ * @since  x.x.x
+ * @return array
+ */
+function sensei_get_certificate_data_fields() {
+	$data_fields = array(
+		'heading' => array(
+			'type' => 'text',
+			'position_label' => __( 'Heading Position', 'sensei-certificates' ),
+			'position_description' => __( 'Optional position of the Certificate Heading', 'sensei-certificates' ),
+			'text_label' => __( 'Heading Text', 'sensei-certificates' ),
+			'text_description' => __( 'Text to display in the heading.', 'sensei-certificates' ),
+			'text_placeholder' => __( 'Certificate of Completion', 'sensei-certificates' ),
+		),
+		'message' => array(
+			'type' => 'textarea',
+			'position_label' => __( 'Message Position', 'sensei-certificates' ),
+			'position_description' => __( 'Optional position of the Certificate Message', 'sensei-certificates' ),
+			'text_label' => __( 'Message Text', 'sensei-certificates' ),
+			'text_description' => __( 'Text to display in the message area.', 'sensei-certificates' ),
+			'text_placeholder' => __( 'This is to certify that', 'sensei-certificates' ) . "\r\n\r\n{{learner}} \r\n\r\n" . __( 'has completed the course', 'sensei-certificates' )
+		),
+		'course' => array(
+			'type' => 'text',
+			'position_label' => __( 'Course Position', 'sensei-certificates' ),
+			'position_description' => __( 'Optional position of the Course Name', 'sensei-certificates' ),
+			'text_label' => __( 'Course Text', 'sensei-certificates' ),
+			'text_description' => __( 'Text to display in the course area.', 'sensei-certificates' ),
+			'text_placeholder' => __( '{{course_title}}', 'sensei-certificates' ),
+		),
+		'completion' => array(
+			'type' => 'text',
+			'position_label' => __( 'Completion Date Position', 'sensei-certificates' ),
+			'position_description' => __( 'Optional position of the Course Completion date', 'sensei-certificates' ),
+			'text_label' => __( 'Completion Date Text', 'sensei-certificates' ),
+			'text_description' => __( 'Text to display in the course completion date area.', 'sensei-certificates' ),
+			'text_placeholder' => __( '{{completion_date}}', 'sensei-certificates' ),
+		),
+		'place' => array(
+			'type' => 'text',
+			'position_label' => __( 'Place Position', 'sensei-certificates' ),
+			'position_description' => __( 'Optional position of the place of Certification.', 'sensei-certificates' ),
+			'text_label' => __( 'Course Place Text', 'sensei-certificates' ),
+			'text_description' => __( 'Text to display in the course place area.', 'sensei-certificates' ),
+			'text_placeholder' => __( '{{course_place}}', 'sensei-certificates' ),
+		),
+	);
+
+	return apply_filters( 'sensei_certificate_data_fields', $data_fields );
+}
 
 
 /**


### PR DESCRIPTION
This is related to issue #93.

These changes add the following two filters:
- `sensei_certificate_data_fields` - This filter allows other plugins to add (or remove) data fields that appear in the Certificate Template editor.
- `sensei_certificate_data_field_value` - This filter is applied to the content of each of the data fields before they are written to the PDF. It provides the following five arguments:
  - `$field_value` - The field content (which will be written to the PDF).
  - `$field_key` - The name of the field the content is being written for. (This could be used to, for example, hide specific data fields under certain conditions.)
  - `$is_preview` - Boolean, true indicates that the certificate being generated is a template preview. When generating a template preview, `$student` and `$course` will be null.
  - `$student` - a WP_User object, the student the certificate is being generated for.
  - `$course` - a WP_Post object, the course the certificate is being generated for.

As an example, a third-party plugin could add a new field as follows:

``` php
add_filter('sensei_certificate_data_fields', 'my_sensei_certificate_data_fields');

function my_sensei_certificate_data_fields($data_fields)
{
    $data_fields['credit_hours'] = array(
        'type' => 'text',
        'position_label' => 'Credit Hours Position',
        'position_description' => 'Optional position of the Credit Hours text',
        'text_label' => 'Credit Hours Text',
        'text_description' => 'Text to display in the Credit Hours area.',
        'text_placeholder' => 'Credit Hours: {{credit_hours}}',
    );

    return $data_fields;
}
```

The `{{credit_hours}}` template tag in this example could be enabled as follows:

``` php
add_filter('sensei_certificate_data_field_value', 'my_sensei_certificate_data_field_value', 10, 5);

function my_sensei_certificate_data_field_value($field_value, $field_key, $is_preview, $student, $course)
{
    if ($is_preview)
    {
        // Just use a sample value of 3
        $credit_hours = '3';
    }
    else
    {
        // Get our custom meta value
        $credit_hours = get_post_meta($course->ID, '_credit_hours', true);
    }

    // If this is the "credit_hours" data field, return an empty string if credit hours weren't specified for this course.
    // This prevents the "Credit Hours:" text from appearing when we don't know how many credit hours the course has.
    if (!$credit_hours && $field_key == 'credit_hours')
        return '';

    return str_replace('{{credit_hours}}', $credit_hours, $field_value);
}
```
