### PR TITLE
Fix fatal when activating certificates for the first time

### DIFF
--- a/woothemes-sensei-certificates.php
+++ b/woothemes-sensei-certificates.php
@@ -197,6 +197,10 @@ function sensei_update_users_certificate_data( $n = 5, $offset = 0 ) {
 	$total_items = $user_count[ 'total_users' ];
 
 	$total_pages = intval( ceil($total_items / $n ) );
+	if ( !class_exists('Woothemes_Sensei_Certificate_Data_Store') ) {
+		include_once( 'classes/class-woothemes-sensei-certificates-data-store.php' );
+	}
+
 	$data_store = new Woothemes_Sensei_Certificate_Data_Store();
 
 	foreach ( $users as $user_key => $user_item ) {


### PR DESCRIPTION
When certificates is activated for the first time,
Includes are not present

Ensure Woothemes_Sensei_Certificate_Data_Store is present before calling
it.