### PR TITLE
I re- commit the work of @misenhower that had done the 100% of the wo…

### DIFF
--- a/admin/post-types/writepanels/writepanel-certificate_data.php
+++ b/admin/post-types/writepanels/writepanel-certificate_data.php
@@ -84,177 +84,47 @@ function certificate_template_data_meta_box( $post ) {
 						'class'       => 'colorpick',
 					) );
 				echo '</div>';
-
-				// Heading
-				echo '<div class="options_group">';
-					certificate_templates_wp_position_picker( array(
-						'id'          => 'certificate_heading_pos',
-						'label'       => __( 'Heading Position', 'sensei-certificates' ),
-						'value'       => implode( ',', $woothemes_sensei_certificate_templates->get_field_position( 'certificate_heading' ) ),
-						'description' => __( 'Optional position of the Certificate Heading', 'sensei-certificates' ),
-					) );
-					certificates_wp_hidden_input( array(
-						'id'    => '_certificate_heading_pos',
-						'class' => 'field_pos',
-						'value' => implode( ',', $woothemes_sensei_certificate_templates->get_field_position( 'certificate_heading' ) ),
-					) );
-					certificate_templates_wp_font_select( array(
-						'id'      => '_certificate_heading',
-						'label'   => __( 'Font', 'sensei-certificates' ),
-						'options' => $available_fonts,
-					) );
-					certificates_wp_text_input( array(
-						'id'    => '_certificate_heading_font_color',
-						'label' => __( 'Font color', 'sensei-certificates' ),
-						'value' => isset( $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_heading']['font']['color'] ) ? $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_heading']['font']['color'] : '',
-						'class' => 'colorpick',
-					) );
-					certificates_wp_text_input( array(
-						'class'       => 'medium',
-						'id'          => '_certificate_heading_text',
-						'label'       => __( 'Heading Text', 'sensei-certificates' ),
-						'description' => __( 'Text to display in the heading.', 'sensei-certificates' ),
-						'placeholder' => __( 'Certificate of Completion', 'sensei-certificates' ),
-						'value'       => isset( $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_heading']['text'] ) ? $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_heading']['text'] : '',
-					) );
-				echo '</div>';
-
-				// Message
-				echo '<div class="options_group">';
-					certificate_templates_wp_position_picker( array(
-						'id'          => 'certificate_message_pos',
-						'label'       => __( 'Message Position', 'sensei-certificates' ),
-						'value'       => implode( ',', $woothemes_sensei_certificate_templates->get_field_position( 'certificate_message' ) ),
-						'description' => __( 'Optional position of the Certificate Message', 'sensei-certificates' ),
-					) );
-					certificates_wp_hidden_input( array(
-						'id'    => '_certificate_message_pos',
-						'class' => 'field_pos',
-						'value' => implode( ',', $woothemes_sensei_certificate_templates->get_field_position( 'certificate_message' ) )
-					) );
-					certificate_templates_wp_font_select( array(
-						'id'      => '_certificate_message',
-						'label'   => __( 'Font', 'sensei-certificates' ),
-						'options' => $available_fonts,
-					) );
-					certificates_wp_text_input( array(
-						'id'    => '_certificate_message_font_color',
-						'label' => __( 'Font color', 'sensei-certificates' ),
-						'value' => isset( $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_message']['font']['color'] ) ? $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_message']['font']['color'] : '',
-						'class' => 'colorpick',
-					) );
-					certificates_wp_textarea_input( array(
-						'class'       => 'medium',
-						'id'          => '_certificate_message_text',
-						'label'       => __( 'Message Text', 'sensei-certificates' ),
-						'description' => __( 'Text to display in the message area.', 'sensei-certificates' ),
-						'placeholder' => __( 'This is to certify that {{learner}} has completed the course', 'sensei-certificates' ),
-						'value'       => isset( $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_message']['text'] ) ? $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_message']['text'] : '',
-					) );
-				echo '</div>';
-
-				// Certificate course position
-				echo '<div class="options_group">';
-					certificate_templates_wp_position_picker( array(
-						'id'          => 'certificate_course_pos',
-						'label'       => __( 'Course Position', 'sensei-certificates' ),
-						'value'       => implode( ',', $woothemes_sensei_certificate_templates->get_field_position( 'certificate_course' ) ),
-						'description' => __( 'Optional position of the Course Name', 'sensei-certificates' ),
-					) );
-					certificates_wp_hidden_input( array(
-						'id'    => '_certificate_course_pos',
-						'class' => 'field_pos',
-						'value' => implode( ',', $woothemes_sensei_certificate_templates->get_field_position( 'certificate_course' ) ),
-					) );
-					certificate_templates_wp_font_select( array(
-						'id'      => '_certificate_course',
-						'label'   => __( 'Font', 'sensei-certificates' ),
-						'options' => $available_fonts,
-					) );
-					certificates_wp_text_input( array(
-						'id'    => '_certificate_course_font_color',
-						'label' => __( 'Font color', 'sensei-certificates' ),
-						'value' => isset( $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_course']['font']['color'] ) ? $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_course']['font']['color'] : '',
-						'class' => 'colorpick',
-					) );
-					certificates_wp_text_input( array(
-						'class'       => 'medium',
-						'id'          => '_certificate_course_text',
-						'label'       => __( 'Course Text', 'sensei-certificates' ),
-						'description' => __( 'Text to display in the course area.', 'sensei-certificates' ),
-						'placeholder' => __( '{{course_title}}', 'sensei-certificates' ),
-						'value'       => isset( $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_course']['text'] ) ? $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_course']['text'] : '',
-					) );
-				echo '</div>';
-
-				// Certificate complete position
-				echo '<div class="options_group">';
-					certificate_templates_wp_position_picker( array(
-						'id'          => 'certificate_completion_pos',
-						'label'       => __( 'Completion Date Position', 'sensei-certificates' ),
-						'value'       => implode( ',', $woothemes_sensei_certificate_templates->get_field_position( 'certificate_completion' ) ),
-						'description' => __( 'Optional position of the Course Completion date', 'sensei-certificates' ),
-					) );
-					certificates_wp_hidden_input( array(
-						'id' => '_certificate_completion_pos',
-						'class' => 'field_pos',
-						'value' => implode( ',', $woothemes_sensei_certificate_templates->get_field_position( 'certificate_completion' ) ),
-					) );
-					certificate_templates_wp_font_select( array(
-						'id'      => '_certificate_completion',
-						'label'   => __( 'Font', 'sensei-certificates' ),
-						'options' => $available_fonts,
-					) );
-					certificates_wp_text_input( array(
-						'id'    => '_certificate_completion_font_color',
-						'label' => __( 'Font color', 'sensei-certificates' ),
-						'value' => isset( $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_completion']['font']['color'] ) ? $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_completion']['font']['color'] : '',
-						'class' => 'colorpick',
-					) );
-					certificates_wp_text_input( array(
-						'class'       => 'medium',
-						'id'          => '_certificate_completion_text',
-						'label'       => __( 'Completion Date Text', 'sensei-certificates' ),
-						'description' => __( 'Text to display in the course completion date area.', 'sensei-certificates' ),
-						'placeholder' => __( '{{completion_date}}', 'sensei-certificates' ),
-						'value'       => isset( $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_completion']['text'] ) ? $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_completion']['text'] : '',
-					) );
-				echo '</div>';
-
-				// Certificate place position
-				echo '<div class="options_group">';
-					certificate_templates_wp_position_picker( array(
-						'id'          => 'certificate_place_pos',
-						'label'       => __( 'Place Position', 'sensei-certificates' ),
-						'value'       => implode( ',', $woothemes_sensei_certificate_templates->get_field_position( 'certificate_place' ) ),
-						'description' => __( 'Optional position of the place of Certification.', 'sensei-certificates' ),
-					) );
-					certificates_wp_hidden_input( array(
-						'id'    => '_certificate_place_pos',
-						'class' => 'field_pos',
-						'value' => implode( ',', $woothemes_sensei_certificate_templates->get_field_position( 'certificate_place' ) ),
-					) );
-					certificate_templates_wp_font_select( array(
-						'id'      => '_certificate_place',
-						'label'   => __( 'Font', 'sensei-certificates' ),
-						'options' => $available_fonts,
-					) );
-					certificates_wp_text_input( array(
-						'id'    => '_certificate_place_font_color',
-						'label' => __( 'Font color', 'sensei-certificates' ),
-						'value' => isset( $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_place']['font']['color'] ) ? $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_place']['font']['color'] : '',
-						'class' => 'colorpick',
-					) );
-					certificates_wp_text_input( array(
-						'class'       => 'medium',
-						'id'          => '_certificate_place_text',
-						'label'       => __( 'Course Place Text', 'sensei-certificates' ),
-						'description' => __( 'Text to display in the course place area.', 'sensei-certificates' ),
-						'placeholder' => __( '{{course_place}}', 'sensei-certificates' ),
-						'value'       => isset( $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_place']['text'] ) ? $woothemes_sensei_certificate_templates->certificate_template_fields['certificate_place']['text'] : '',
-					) );
-				echo '</div>';
-
+				
+				// Data fields
+ 				$data_fields = sensei_get_certificate_data_fields();
+ 				foreach ( $data_fields as $field_key => $field_info ) {
+ 
+ 					echo '<div class="options_group">';
+ 						certificate_templates_wp_position_picker( array(
+ 							'id'          => "certificate_{$field_key}_pos",
+ 							'label'       => $field_info['position_label'],
+ 							'value'       => implode( ',', $woothemes_sensei_certificate_templates->get_field_position( "certificate_$field_key" ) ),
+ 							'description' => $field_info['position_description'],
+ 						) );
+ 						certificates_wp_hidden_input( array(
+ 							'id'    => "_certificate_{$field_key}_pos",
+ 							'class' => 'field_pos',
+ 							'value' => implode( ',', $woothemes_sensei_certificate_templates->get_field_position( "certificate_$field_key" ) ),
+ 						) );
+ 						certificate_templates_wp_font_select( array(
+ 							'id'      => "_certificate_$field_key",
+ 							'label'   => __( 'Font', 'sensei-certificates' ),
+ 							'options' => $available_fonts,
+ 						) );
+ 						certificates_wp_text_input( array(
+ 							'id'    => "_certificate_{$field_key}_font_color",
+ 							'label' => __( 'Font color', 'sensei-certificates' ),
+ 							'value' => isset( $woothemes_sensei_certificate_templates->certificate_template_fields["certificate_$field_key"]['font']['color'] ) ? $woothemes_sensei_certificate_templates->certificate_template_fields["certificate_$field_key"]['font']['color'] : '',
+ 							'class' => 'colorpick',
+ 						) );
+ 
+ 						$text_function = ( $field_info['type'] == 'textarea' ) ? 'certificates_wp_textarea_input' : 'certificates_wp_text_input';
+ 						$text_function( array(
+ 							'class'       => 'medium',
+ 							'id'          => "_certificate_{$field_key}_text",
+ 							'label'       => $field_info['text_label'],
+ 							'description' => $field_info['text_description'],
+ 							'placeholder' => $field_info['text_placeholder'],
+ 							'value'       => isset( $woothemes_sensei_certificate_templates->certificate_template_fields["certificate_$field_key"]['text'] ) ? $woothemes_sensei_certificate_templates->certificate_template_fields["certificate_$field_key"]['text'] : '',
+ 						) );
+ 					echo '</div>';
+ 				}
+				
 			?>
 		</div>
 	</div>
@@ -288,7 +158,10 @@ function certificate_templates_process_meta( $post_id, $post ) {
 	// original sizes: default 11, product name 16, sku 8
 	// create the certificate template fields data structure
 	$fields = array();
-	foreach ( array( '_certificate_heading', '_certificate_message', '_certificate_course', '_certificate_completion', '_certificate_place' ) as $i => $field_name ) {
+	$data_fields = sensei_get_certificate_data_fields();
+	foreach ( array_keys($data_fields) as $i => $field_key ) {
+		
+		$field_name = '_certificate_' . $field_key;
 
 		// set the field defaults
 		$field = array(

--- a/woothemes-sensei-certificates.php
+++ b/woothemes-sensei-certificates.php
@@ -21,6 +21,7 @@
  * - sensei_certificates_updates_list()
  * - sensei_update_users_certificate_data()
  * - sensei_create_master_certificate_template()
+ * - sensei_get_certificate_data_fields()
  * - is_sensei_active()
  */
 
@@ -412,6 +413,59 @@ function sensei_create_master_certificate_template() {
 
 } // End sensei_create_master_certificate_template()
 
+
+/*
+  * sensei_get_certificate_data_fields gets the data fields that are applied to each certificate.
+  * @since  x.x.x
+  * @return array
+  */
+function sensei_get_certificate_data_fields() {
+	$data_fields = array(
+	    'heading' => array(
+	        'type' => 'text',
+	        'position_label' => __( 'Heading Position', 'sensei-certificates' ),
+	        'position_description' => __( 'Optional position of the Certificate Heading', 'sensei-certificates' ),
+	        'text_label' => __( 'Heading Text', 'sensei-certificates' ),
+	        'text_description' => __( 'Text to display in the heading.', 'sensei-certificates' ),
+	        'text_placeholder' => __( 'Certificate of Completion', 'sensei-certificates' ),
+	    ),
+	    'message' => array(
+	        'type' => 'textarea',
+	        'position_label' => __( 'Message Position', 'sensei-certificates' ),
+	        'position_description' => __( 'Optional position of the Certificate Message', 'sensei-certificates' ),
+	        'text_label' => __( 'Message Text', 'sensei-certificates' ),
+	        'text_description' => __( 'Text to display in the message area.', 'sensei-certificates' ),
+	        'text_placeholder' => __( 'This is to certify that', 'sensei-certificates' ) . "\r\n\r\n{{learner}} \r\n\r\n" . __( 'has completed the course', 'sensei-certificates' )
+	    ),
+	    'course' => array(
+	        'type' => 'text',
+	        'position_label' => __( 'Course Position', 'sensei-certificates' ),
+	        'position_description' => __( 'Optional position of the Course Name', 'sensei-certificates' ),
+	        'text_label' => __( 'Course Text', 'sensei-certificates' ),
+	        'text_description' => __( 'Text to display in the course area.', 'sensei-certificates' ),
+	        'text_placeholder' => __( '{{course_title}}', 'sensei-certificates' ),
+	    ),
+	    'completion' => array(
+	        'type' => 'text',
+	        'position_label' => __( 'Completion Date Position', 'sensei-certificates' ),
+	        'position_description' => __( 'Optional position of the Course Completion date', 'sensei-certificates' ),
+	        'text_label' => __( 'Completion Date Text', 'sensei-certificates' ),
+	        'text_description' => __( 'Text to display in the course completion date area.', 'sensei-certificates' ),
+	        'text_placeholder' => __( '{{completion_date}}', 'sensei-certificates' ),
+	    ),
+	    'place' => array(
+	        'type' => 'text',
+	        'position_label' => __( 'Place Position', 'sensei-certificates' ),
+	        'position_description' => __( 'Optional position of the place of Certification.', 'sensei-certificates' ),
+	        'text_label' => __( 'Course Place Text', 'sensei-certificates' ),
+	        'text_description' => __( 'Text to display in the course place area.', 'sensei-certificates' ),
+	        'text_placeholder' => __( '{{course_place}}', 'sensei-certificates' ),
+	    ),
+	);
+	
+	return apply_filters( 'sensei_certificate_data_fields', $data_fields );
+}
+ 
 
 /**
  * Functions used by plugins


### PR DESCRIPTION
All the credit goes to @misenhower who have done all the work

This is related to issue #93.

These changes add the following two filters:

- ```sensei_certificate_data_fields```

 - This filter allows other plugins to add (or remove) data fields that appear in the Certificate Template editor.
```sensei_certificate_data_field_value``` - This filter is applied to the content of each of the data fields before they are written to the PDF. It provides the following five arguments:
   - ```$field_value``` - The field content (which will be writte - n to the PDF).
   - ```$field_key``` - The name of the field the content is being written for. (This could be used to, for example, hide specific data fields under certain conditions.)
   - ```$is_preview``` - Boolean, true indicates that the certificate being generated is a template preview. When generating a template preview, ```$student``` and ```$course``` will be null.
    - ```$student``` - a WP_User object, the student the certificate is being generated for.
    - ```$course``` - a WP_Post object, the course the certificate is being generated for.

 As an example, a third-party plugin could add a new field as follows:
```
add_filter('sensei_certificate_data_fields', 'my_sensei_certificate_data_fields');

function my_sensei_certificate_data_fields($data_fields)
{
    $data_fields['credit_hours'] = array(
        'type' => 'text',
        'position_label' => 'Credit Hours Position',
        'position_description' => 'Optional position of the Credit Hours text',
        'text_label' => 'Credit Hours Text',
        'text_description' => 'Text to display in the Credit Hours area.',
        'text_placeholder' => 'Credit Hours: {{credit_hours}}',
    );

    return $data_fields;
}
```
The ```{{credit_hours}}``` template tag in this example could be enabled as follows:

```
add_filter('sensei_certificate_data_field_value', 'my_sensei_certificate_data_field_value', 10, 5);

function my_sensei_certificate_data_field_value($field_value, $field_key, $is_preview, $student, $course)
{
    if ($is_preview)
    {
        // Just use a sample value of 3
        $credit_hours = '3';
    }
    else
    {
        // Get our custom meta value
        $credit_hours = get_post_meta($course->ID, '_credit_hours', true);
    }

    // If this is the "credit_hours" data field, return an empty string if credit hours weren't specified for this course.
    // This prevents the "Credit Hours:" text from appearing when we don't know how many credit hours the course has.
    if (!$credit_hours && $field_key == 'credit_hours')
        return '';

    return str_replace('{{credit_hours}}', $credit_hours, $field_value);
}
```