### PR TITLE
Update date formatting to match WP Settings

### DIFF
--- a/classes/class-woothemes-sensei-certificate-templates.php
+++ b/classes/class-woothemes-sensei-certificate-templates.php
@@ -151,7 +151,7 @@ class WooThemes_Sensei_Certificate_Templates {
 			    'all_items' => __( 'Certificate Templates', 'sensei-certificates' ),
 			    'view_item' => __( 'View Certificate Template', 'sensei-certificates' ),
 			    'search_items' => __( 'Search Certificate Templates', 'sensei-certificates' ),
-			    'not_found' =>  __( 'No certificate templates found', 'sensei-certificates' ), 
+			    'not_found' =>  __( 'No certificate templates found', 'sensei-certificates' ),
 			    'not_found_in_trash' => __( 'No certificate templates found in Trash', 'sensei-certificates' ),
 			    'parent_item_colon' => '',
 			    'menu_name' => __( 'Certificate Templates', 'sensei-certificates' )
@@ -442,17 +442,8 @@ class WooThemes_Sensei_Certificate_Templates {
 
 		} // End For Loop
 
-		// Set default fonts
-		setlocale(LC_TIME, get_locale() );
+		$date = Woothemes_Sensei_Certificates_Utils::get_certificate_formatted_date( $course_end_date );
 
-		if( false !== strpos( get_locale(), 'en' ) ) {
-			$date_format = apply_filters( 'sensei_certificate_date_format', 'jS F Y' );
-			$date = date( $date_format, strtotime( $course_end_date ) );
-		} else {
-			$date_format = apply_filters( 'sensei_certificate_date_format', '%Y %B %e' );
-			$date = strftime ( $date_format, strtotime( $course_end_date ) );
-		}
-		
 		$certificate_heading = __( 'Certificate of Completion', 'sensei-certificates' ); // Certificate of Completion
 		if ( isset( $this->certificate_template_fields['certificate_heading']['text'] ) && '' != $this->certificate_template_fields['certificate_heading']['text'] ) {
 

--- a/classes/class-woothemes-sensei-certificates-utils.php
+++ b/classes/class-woothemes-sensei-certificates-utils.php
@@ -17,4 +17,45 @@ class Woothemes_Sensei_Certificates_Utils {
     public static function get_certificate_hash( $course_id, $user_id ) {
         return esc_html( substr( md5( $course_id . $user_id ), -8 ) );
     }
+
+	/**
+	 * Get the formatted date string to be used on a Certificate.
+	 *
+	 * @param  string $course_end_date The course end date to use.
+	 *
+	 * @return string The formatted date string.
+	 */
+	public static function get_certificate_formatted_date( $course_end_date ) {
+		$default_date_format = get_option( 'date_format' );
+		$date_format = apply_filters( 'sensei_certificate_date_format', $default_date_format );
+
+		/*
+		 * For backwards compatibility, check if we're using a strftime format
+		 * string for a non-English locale.
+		 */
+		$should_use_strftime = ( false === strpos( get_locale(), 'en' ) )
+			&& self::date_format_is_for_strftime( $date_format );
+
+		if ( $should_use_strftime ) {
+			setlocale( LC_TIME, get_locale() );
+			return strftime( $date_format, strtotime( $course_end_date ) );
+		}
+
+		return date_i18n( $date_format, strtotime( $course_end_date ) );
+	}
+
+	/**
+	 * Checks whether a date format string is meant for `strftime()` instead of
+	 * `date()`.
+	 *
+	 * @param  string $date_format The date format.
+	 *
+	 * @return boolean true if the date format should be used with `strftime()`.
+	 */
+	private static function date_format_is_for_strftime( $date_format ) {
+		return preg_match(
+			'/%(a|A|d|e|j|u|w|U|V|W|b|B|h|m|C|g|G|y|Y|H|k|I|l|M|p|P|r|R|S|T|X|z|Z|c|D|F|s|x|n|t|%)/',
+			$date_format
+		);
+	}
 }

--- a/classes/class-woothemes-sensei-certificates-utils.php
+++ b/classes/class-woothemes-sensei-certificates-utils.php
@@ -27,6 +27,14 @@ class Woothemes_Sensei_Certificates_Utils {
 	 */
 	public static function get_certificate_formatted_date( $course_end_date ) {
 		$default_date_format = get_option( 'date_format' );
+
+		/**
+		 * Filter the date format to be used for certificates. The date format
+		 * syntax should be the format required by PHP's `date()` function.
+		 *
+		 * @param  string $default_date_format The default date format to be used.
+		 * @return string The date format to use.
+		 */
 		$date_format = apply_filters( 'sensei_certificate_date_format', $default_date_format );
 
 		/*

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -547,16 +547,7 @@ class WooThemes_Sensei_Certificates {
 			if ( isset( $this->certificate_font_family ) && '' != $this->certificate_font_family ) { $pdf_certificate->certificate_pdf_data['font_family'] = $this->certificate_font_family; }
 			if ( isset( $this->certificate_font_style ) && '' != $this->certificate_font_style ) { $pdf_certificate->certificate_pdf_data['font_style'] = $this->certificate_font_style; }
 
-			// Set default fonts
-			setlocale(LC_TIME, get_locale() );
-
-			if( false !== strpos( get_locale(), 'en' ) ) {
-				$date_format = apply_filters( 'sensei_certificate_date_format', 'jS F Y' );
-				$date = date( $date_format, strtotime( $course_end_date ) );
-			} else {
-				$date_format = apply_filters( 'sensei_certificate_date_format', '%Y %B %e' );
-				$date = strftime ( $date_format, strtotime( $course_end_date ) );
-			}
+			$date = Woothemes_Sensei_Certificates_Utils::get_certificate_formatted_date( $course_end_date );
 
 			$certificate_heading = __( 'Certificate of Completion', 'sensei-certificates' ); // Certificate of Completion
 			if ( isset( $this->certificate_template_fields['certificate_heading']['text'] ) && '' != $this->certificate_template_fields['certificate_heading']['text'] ) {


### PR DESCRIPTION
Fixes #72 

This PR modifies the way that date format handling works for Sensei Certificates. The following changes are being made:

- If the `sensei_certificate_date_format` filter is _not_ used to customize the date format, the format in WordPress's Settings will be used instead.
  - This is true regardless of the locale.
- The aforementioned filter now expects the date format to be given in the syntax required by the [`date`](http://php.net/manual/en/function.date.php) function, regardless of the locale.

## Backwards Compatibility

Previously, the date formatting function being used was different based on whether or not the locale of the site was English. See [this blog post](https://seesensei.com/2017/04/25/change-the-date-format-on-a-certificate/) for the instructions on how to use the filter, and note the difference for English and non-English locales. Non-English locales were using `strftime()` instead of `date()`.

In this PR, we use `date_i18n()` regardless of the locale. This is [the recommended way](https://codex.wordpress.org/Formatting_Date_and_Time#Localization) to localize dates in WordPress. It automatically handles translating month names, day names, etc.

However, this breaks backward compatibility for any site that is using the filter and returning a format string to be used by `strftime()` in a non-English locale. I've added [fallback code](https://github.com/woocommerce/sensei-certificates/pull/150/files#diff-934a243979e63be379fc623fcd736269R44) to this PR for such a case. It's not ideal, but it's safer than removing support for the `strftime()` format, since there may be people using it.

## Documentation

When this lands, the [documentation](https://docs.woocommerce.com/document/sensei-certificates/#section-9) should be updated, and we may want to edit [this post](https://seesensei.com/2017/04/25/change-the-date-format-on-a-certificate/).

## Testing

- Create a certificate template and a certificate for a user who completed a course. For the following steps, inspect both the PDF for the certificate itself, and the previewed certificate template (the two are rendered somewhat differently).

- Set the site language to English, and do not use the `sensei_certificate_date_format` filter. The rendered dates should follow the WP Setting for the date format. Try changing the format, and make sure that the certificates reflect the change.

- Do the same as above for a language other than English. You should get the same results.

- Use the filter to change the format. Please use a format supported by [`date()`](http://php.net/manual/en/function.date.php). The new format should be used instead of the WP Setting. Try this with the site's locale set to English, and a language other than English. Here is some example code:

```php
function new_cert_date_format( $format ) {
  return 'Y-m-d';
}
add_filter( 'sensei_certificate_date_format', 'new_cert_date_format' );
```

- Try using a format supported by [`strftime()`](http://php.net/manual/en/function.strftime.php) on both an English locale and a non-English locale. For the non-English locale, this format should work as a fallback. For the English locale, this format should not work properly.