### PR TITLE
Make custom_menu_order filter run later than WooCommerce

### DIFF
--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -115,8 +115,8 @@ class WooThemes_Sensei_Certificates {
 			add_filter( 'option_wpseo_titles', array( $this, 'force_hide_wpseo_meta_box' ) );
 
 			// Reorder the admin menus to display Certificates below Lessons.
-			add_filter( 'custom_menu_order' , '__return_true');
-			add_action( 'menu_order', array( $this, 'admin_menu_order' ) );
+			add_filter( 'custom_menu_order' , '__return_true', 20 );
+			add_filter( 'menu_order', array( $this, 'admin_menu_order' ) );
 		}
 
 		// Generate certificate hash when course is completed.


### PR DESCRIPTION
Fixes #126

See the issue for a description of the bug.

The bug was happening because WooCommerce was setting the `custom_menu_order` filter to return `false` for users who could not manage WooCommerce. This was causing the custom menu ordering for Sensei Certificates to stop working for non-admin users (i.e. Teachers).

This workaround causes our filter function to be run later than WooCommerce's function, meaning that `custom_menu_order` will be `true`.

I've also [submitted a patch to WooCommerce](https://github.com/woocommerce/woocommerce/pull/20856) which should cause this not to happen for other plugins.

## Testing

- Install WooCommerce.

- Log in as an Admin user, and as a Teacher. In both cases, ensure that the Certificates menu item appears below the Lesson menu item.