### PR TITLE
Fix Trash link on Certificate Templates screen

### DIFF
--- a/admin/post-types/certificate_templates.php
+++ b/admin/post-types/certificate_templates.php
@@ -156,7 +156,7 @@ function certificate_template_custom_certificate_columns( $column ) {
 
 			foreach ( $actions as $action => $link ) {
 				( $action_count - 1 == $i ) ? $sep = '' : $sep = ' | ';
-				echo '<span class="' . esc_attr( $action ) . '">' . esc_html( $link . $sep ) . '</span>';
+				echo '<span class="' . esc_attr( $action ) . '">' . wp_kses_post( $link . $sep ) . '</span>';
 				$i++;
 			} // End For Loop
 			echo '</div>';


### PR DESCRIPTION
## Testing
1. Create a certificate template or hover over an existing one on the _Certificate Templates_ screen.
2. Ensure the trash link is visible and works.