### PR TITLE
Fix Restore link for Certificate Templates

### DIFF
--- a/admin/post-types/certificate_templates.php
+++ b/admin/post-types/certificate_templates.php
@@ -140,7 +140,7 @@ function certificate_template_custom_certificate_columns( $column ) {
 
 			if ( current_user_can( $post_type_object->cap->delete_post, $post->ID ) ) {
 				if ( 'trash' == $post->post_status )
-					$actions['untrash'] = "<a title='" . esc_attr( __( 'Restore this item from the Trash', 'sensei-certificates' ) ) . "' href='" . wp_nonce_url( admin_url( sprintf( $post_type_object->_edit_link . '&amp;action=untrash', $post->ID ) ), 'untrash-' . $post->post_type . '_' . $post->ID ) . "'>" . __( 'Restore', 'sensei-certificates' ) . "</a>";
+					$actions['untrash'] = "<a title='" . esc_attr( __( 'Restore this item from the Trash', 'sensei-certificates' ) ) . "' href='" . wp_nonce_url( admin_url( sprintf( $post_type_object->_edit_link . '&amp;action=untrash', $post->ID ) ), 'untrash-post_' . $post->ID ) . "'>" . __( 'Restore', 'sensei-certificates' ) . "</a>";
 				elseif ( EMPTY_TRASH_DAYS )
 					$actions['trash'] = "<a class='submitdelete' title='" . esc_attr( __( 'Move this item to the Trash', 'sensei-certificates' ) ) . "' href='" . get_delete_post_link( $post->ID ) . "'>" . __( 'Trash', 'sensei-certificates' ) . "</a>";
 				if ( 'trash' == $post->post_status || ! EMPTY_TRASH_DAYS )


### PR DESCRIPTION
Nonce check changed in WP core back in 2012 (https://github.com/WordPress/WordPress/commit/4974f5f233f1ba2c86a4501022b057421c2c1b8b), so isn't a new bug.

## Steps to Test
1. Delete a Certificate Template from WP Admin.
2. Go to Certificate Template trash.
3. Click Restore link (bulk actions should have always worked).
4. Verify it restores the template.

