### PR TITLE
Do not show link to certificate with no template

### DIFF
--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -378,7 +378,23 @@ class WooThemes_Sensei_Certificates {
 				echo wp_kses_post( $course_end_date );
 				break;
 			case 'actions':
-				echo '<a href="' . esc_url( get_permalink( $post_ID ) ) . '" target="_blank">' . esc_html__( 'View Certificate', 'sensei-certificates' ) . '</a>';
+				$template_id = get_post_meta( $course_id, '_course_certificate_template', true );
+				if ( $template_id ) {
+					echo '<a href="' . esc_url( get_permalink( $post_ID ) ) . '" target="_blank">' . esc_html__( 'View Certificate', 'sensei-certificates' ) . '</a>';
+				} else {
+					$course_link = sprintf(
+						'<a href="%1$s">%2$s</a>',
+						esc_url( get_edit_post_link( $course_id ) ),
+						__( 'Course', 'sensei-certificates' )
+					);
+					echo wp_kses_post(
+						sprintf(
+							// translators: %1$s is a link to the Course.
+							__( 'Set a Certificate Template on the %1$s in order to view this certificate' ),
+							$course_link
+						)
+					);
+				}
 				break;
 		} // End Switch Statement
 

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -382,16 +382,11 @@ class WooThemes_Sensei_Certificates {
 				if ( $template_id ) {
 					echo '<a href="' . esc_url( get_permalink( $post_ID ) ) . '" target="_blank">' . esc_html__( 'View Certificate', 'sensei-certificates' ) . '</a>';
 				} else {
-					$course_link = sprintf(
-						'<a href="%1$s">%2$s</a>',
-						esc_url( get_edit_post_link( $course_id ) ),
-						__( 'Course', 'sensei-certificates' )
-					);
 					echo wp_kses_post(
 						sprintf(
-							// translators: %1$s is a link to the Course.
-							__( 'Set a Certificate Template on the %1$s in order to view this certificate' ),
-							$course_link
+							// translators: %1$s is the URL for editing the Course.
+							__( 'Set a certificate template on the <a href="%1$s">course</a> in order to view this certificate', 'sensei-certificates' ),
+							esc_url( get_edit_post_link( $course_id ) )
 						)
 					);
 				}


### PR DESCRIPTION
Closes https://github.com/woocommerce/sensei-certificates/issues/107

There were a few possible solutions to this problem.

Sensei Certificates does create a certificate for every user who completes a course, but the "View Certificate" link does not show up on the _frontend_ unless the certificate has a template. If a course does not have a template, but later a template is added, then the users who completed the course before it was added will get links to their certificates at that point.

With that in mind, I don't think that preventing the creation of the certificate is the right answer. Instead, I changed the "View Certificate" link in the backend table to only display when the course has a certificate template. Otherwise, the admin user is prompted to add the template in order to view the certificate.

To test, follow the instructions in #107 