### PR TITLE
Add certificate link to emails

### DIFF
--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -1193,6 +1193,14 @@ class WooThemes_Sensei_Certificates {
 
 	} // End certificates_user_settings_message()
 
+	/**
+	 * Output the "View certificate" link for emails.
+	 *
+	 * @access private
+	 * @since 2.0.0
+	 *
+	 * @param string $template The email template being rendered.
+	 */
 	public function email_certificate_link( $template ) {
 		global $sensei_email_data;
 

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -127,7 +127,7 @@ class WooThemes_Sensei_Certificates {
 		}
 
 		// Generate certificate hash when course is completed.
-		add_action( 'sensei_user_course_end', array( $this, 'generate_certificate_number' ), 10, 2 );
+		add_action( 'sensei_course_status_updated', array( $this, 'generate_certificate_number' ), 9, 4 );
 		// Background Image to display on certificate
 		add_action( 'sensei_certificates_set_background_image', array( $this, 'certificate_background' ), 10, 1 );
 		// Text to display on certificate
@@ -399,9 +399,9 @@ class WooThemes_Sensei_Certificates {
 	 * @param  int $course_id data to post
 	 * @return void
 	 */
-	public function generate_certificate_number( $user_id = 0, $course_id = 0 ) {
+	public function generate_certificate_number( $status, $user_id = 0, $course_id = 0 ) {
 
-		if ( ! $user_id || ! $course_id || ! is_numeric( $user_id ) || ! is_numeric( $course_id ) ) {
+		if ( 'complete' !== $status || ! $user_id || ! $course_id || ! is_numeric( $user_id ) || ! is_numeric( $course_id ) ) {
 			return;
 		}
 		$user_id   = absint( $user_id );

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -127,7 +127,7 @@ class WooThemes_Sensei_Certificates {
 		}
 
 		// Generate certificate hash when course is completed.
-		add_action( 'sensei_course_status_updated', array( $this, 'generate_certificate_number' ), 9, 4 );
+		add_action( 'sensei_course_status_updated', array( $this, 'handle_course_completed' ), 9, 3 );
 		// Background Image to display on certificate
 		add_action( 'sensei_certificates_set_background_image', array( $this, 'certificate_background' ), 10, 1 );
 		// Text to display on certificate
@@ -389,6 +389,24 @@ class WooThemes_Sensei_Certificates {
 
 	} // End post_type_custom_column_content()
 
+	/**
+	 * Ensure certificate is generated on course completion.
+	 *
+	 * @access private
+	 * @since 2.0.0
+	 *
+	 * @param string $status    The new course status.
+	 * @param int    $user_id   The ID of the learner.
+	 * @param int    $course_id The ID of the course.
+	 * @return void
+	 */
+	public function handle_course_completed( $status, $user_id, $course_id ) {
+		if ( 'complete' !== $status ) {
+			return;
+		}
+
+		$this->generate_certificate_number( $user_id, $course_id );
+	}
 
 	/**
 	 * Generate unique certificate hash and save as comment.
@@ -399,9 +417,9 @@ class WooThemes_Sensei_Certificates {
 	 * @param  int $course_id data to post
 	 * @return void
 	 */
-	public function generate_certificate_number( $status, $user_id = 0, $course_id = 0 ) {
+	public function generate_certificate_number( $user_id = 0, $course_id = 0 ) {
 
-		if ( 'complete' !== $status || ! $user_id || ! $course_id || ! is_numeric( $user_id ) || ! is_numeric( $course_id ) ) {
+		if ( ! $user_id || ! $course_id || ! is_numeric( $user_id ) || ! is_numeric( $course_id ) ) {
 			return;
 		}
 		$user_id   = absint( $user_id );

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -104,6 +104,11 @@ class WooThemes_Sensei_Certificates {
 		add_action( 'sensei_frontend_messages', array( $this, 'certificates_user_settings_messages' ), 10 );
 
 		/**
+		 * Emails
+		 */
+		add_action( 'sensei_after_email_content', array( $this, 'email_certificate_link' ) );
+
+		/**
 		 * BACKEND
 		 */
 		if ( is_admin() ) {
@@ -1169,5 +1174,37 @@ class WooThemes_Sensei_Certificates {
 		} // End If Statement
 
 	} // End certificates_user_settings_message()
+
+	public function email_certificate_link( $template ) {
+		global $sensei_email_data;
+
+		// Only handle emails for course completion.
+		if ( ! ( 'learner-completed-course' === $template || 'teacher-completed-course' === $template ) ) {
+			return;
+		}
+
+		// Get ID of learner who completed the course.
+		$user_id = null;
+		if ( 'learner-completed-course' === $template ) {
+			$user_id = $sensei_email_data['user_id'];
+		} else {
+			$user_id = $sensei_email_data['learner_id'];
+		}
+
+		$course_id   = $sensei_email_data['course_id'];
+		$template_id = get_post_meta( $course_id, '_course_certificate_template', true );
+
+		// Only include the link if the certificate has a template.
+		if ( $template_id ) {
+			$certificate_url  = $this->get_certificate_url( $course_id, $user_id );
+?>
+			<p style="text-align: center !important">
+				<a href="<?php echo esc_url( $certificate_url ); ?>" target="_blank">
+					<?php echo esc_html__( 'View certificate', 'sensei-certificates' ); ?>
+				</a>
+			</p>
+<?php
+		}
+	}
 
 } // End Class


### PR DESCRIPTION
Fixes https://github.com/woocommerce/sensei-certificates/issues/80

This adds a link to "View certificate" to the emails that are sent on course completion. This includes the email to the learner, and the email to the teacher.

## Testing instructions

- In Sensei Settings, ensure email notifications are enabled for both the teacher and the learner when a course is completed.
- Complete a course.
- In both the email to the learner, and the email to the teacher, there should be a link to view the certificate.

## Implementation note

I moved the certificate generation code to the `sensei_course_status_updated` hook instead of the `sensei_user_course_end` hook. This is because we need the certificate to be generated _before_ the emails are sent so that we can access its permalink and add it to the email. The emails are sent on the `sensei_course_status_updated` with priority 10 ([see the code here](https://github.com/Automattic/sensei/blob/0d2cb08f4fb3f6c6eae752429812fe94242480d6/includes/class-sensei-emails.php#L45)).