### PR TITLE
Remove CPTs from public search queries

### DIFF
--- a/classes/class-woothemes-sensei-certificate-templates.php
+++ b/classes/class-woothemes-sensei-certificate-templates.php
@@ -145,7 +145,7 @@ class WooThemes_Sensei_Certificate_Templates {
 	public function setup_certificate_templates_post_type() {
 
 		$args = array(
-			'labels'             => array(
+			'labels'              => array(
 				'name'               => _x( 'Certificate Templates', 'post type general name', 'sensei-certificates' ),
 				'singular_name'      => _x( 'Certificate Template', 'post type singular name', 'sensei-certificates' ),
 				'add_new'            => _x( 'Add New Certificate Template', 'post type add_new', 'sensei-certificates' ),
@@ -160,23 +160,24 @@ class WooThemes_Sensei_Certificate_Templates {
 				'parent_item_colon'  => '',
 				'menu_name'          => __( 'Certificate Templates', 'sensei-certificates' ),
 			),
-			'public'             => true,
-			'publicly_queryable' => true,
-			'show_ui'            => true,
-			'show_in_menu'       => 'edit.php?post_type=certificate',
-			'query_var'          => true,
-			'rewrite'            => array(
+			'public'              => true,
+			'publicly_queryable'  => true,
+			'exclude_from_search' => true,
+			'show_ui'             => true,
+			'show_in_menu'        => 'edit.php?post_type=certificate',
+			'query_var'           => true,
+			'rewrite'             => array(
 				'slug'       => esc_attr( apply_filters( 'sensei_certificate_templates_slug', 'certificate-template' ) ),
 				'with_front' => true,
 				'feeds'      => true,
 				'pages'      => true,
 			),
-			'capability_type'    => 'certificate_template',
-			'map_meta_cap'       => true,
-			'has_archive'        => false,
-			'hierarchical'       => false,
-			'menu_icon'          => esc_url( Sensei()->plugin_url . 'assets/images/certificate.png' ),
-			'supports'           => array( 'title' ),
+			'capability_type'     => 'certificate_template',
+			'map_meta_cap'        => true,
+			'has_archive'         => false,
+			'hierarchical'        => false,
+			'menu_icon'           => esc_url( Sensei()->plugin_url . 'assets/images/certificate.png' ),
+			'supports'            => array( 'title' ),
 		);
 
 		register_post_type( 'certificate_template', $args );

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -393,7 +393,7 @@ class WooThemes_Sensei_Certificates {
 	public function setup_certificates_post_type() {
 
 		$args = array(
-			'labels'             => array(
+			'labels'              => array(
 				'name'               => _x( 'Certificates', 'post type general name', 'sensei-certificates' ),
 				'singular_name'      => _x( 'Certificate', 'post type singular name', 'sensei-certificates' ),
 				'add_new'            => _x( 'Add New Certificate', 'post type add_new', 'sensei-certificates' ),
@@ -408,23 +408,24 @@ class WooThemes_Sensei_Certificates {
 				'parent_item_colon'  => '',
 				'menu_name'          => __( 'Certificates', 'sensei-certificates' ),
 			),
-			'public'             => true,
-			'publicly_queryable' => true,
-			'show_ui'            => true,
-			'query_var'          => true,
-			'rewrite'            => array(
+			'public'              => true,
+			'publicly_queryable'  => true,
+			'exclude_from_search' => true,
+			'show_ui'             => true,
+			'query_var'           => true,
+			'rewrite'             => array(
 				'slug'       => esc_attr( apply_filters( 'sensei_certificates_slug', 'certificate' ) ),
 				'with_front' => true,
 				'feeds'      => true,
 				'pages'      => true,
 			),
-			'capability_type'    => 'certificate',
-			'map_meta_cap'       => true,
-			'has_archive'        => false,
-			'hierarchical'       => false,
-			'menu_icon'          => 'dashicons-awards',
-			'menu-position'      => 21,
-			'supports'           => array( 'title', 'custom-fields' ),
+			'capability_type'     => 'certificate',
+			'map_meta_cap'        => true,
+			'has_archive'         => false,
+			'hierarchical'        => false,
+			'menu_icon'           => 'dashicons-awards',
+			'menu-position'       => 21,
+			'supports'            => array( 'title', 'custom-fields' ),
 		);
 
 		register_post_type( 'certificate', $args );


### PR DESCRIPTION
This fixes an issue where certificates could show up in search results. When unauthorized users clicked on them they would be inaccessible, but it still makes a mess of the search results. It probably doesn't happen that often as the certificate titles are random alphanumeric characters.

### Testing Instructions
- Complete a course and make sure a certificate is generated.
- Search for part of the certificate or certificate title. For example: `http://example.com/?s=2c5b9af1`.
- Verify it doesn't show up in search results.

Might be easier to hide whitespace changes for this review.