### PR TITLE
Don't hide template positioning box when clicking off it

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -189,6 +189,7 @@ jQuery( function($){
 			instance: true,
 			imageWidth: imageWidth,
 			imageHeight: imageHeight,
+			persistent: true,
 			x1: coords[0],
 			y1: coords[1],
 			x2: coords[0] + coords[2],
@@ -250,7 +251,7 @@ jQuery( function($){
 
 		return false;
 	});
-	
+
 	if ( typeof jQuery.fn.hasParent !== 'function' ) {
 			jQuery.extend( jQuery.fn, {
 			// Name of our method & one argument (the parent selector)


### PR DESCRIPTION
Fixes #4 .

The `jquery.imgareaSelect.js` file, which is bundled with WordPress and that Certificates uses to overlay boxes on top of the certificate template, hasn't been updated since 2013. 😱Although the options aren't well-documented, setting the `persistent` option to `true` [doesn't attach the `mousedown` event handler](https://github.com/odyniec/imgareaselect/blob/master/jquery.imgareaselect.dev.js#L1004), which [would ultimately hide the element](https://github.com/odyniec/imgareaselect/blob/master/jquery.imgareaselect.dev.js#L707).

On testing, it doesn't appear that removing the `mousedown` event has a negative impact on functionality.

## Testing Instructions
- Edit a certificate template.
- Click on a box on top of the image and drag it and/or resize it.
- Click on the image, outside of the box.
- Ensure the box does not disappear.
- Click _Update_.
- The box position and size should be retained.
- Edit the template again, but this time click the _Set Position_ button in _Certificate Data_, resize and/or move the box, click outside the box, and then click _Done_.
- The box position and size should be retained.