### PR TITLE
Reset certificate template image when clicking off selected box

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -197,6 +197,12 @@ jQuery( function($){
 			onSelectEnd: function(img, selection) { areaSelect(selection, field_name); }
 		});
 
+		// Remove image area select element when clicking elsewhere on the image.
+		$( '.imgareaselect-outer' ).click( function() {
+			removeImgAreaSelect();
+			$( '.set_position' ).val(sensei_certificate_templates_params.set_position_label);
+		} );
+
 		// scroll into viewport if needed
 		if ($(document).scrollTop() > $("img#certificate_image_0").offset().top + $("img#certificate_image_0").height() * (2/3)) {
 			$('html, body').animate({


### PR DESCRIPTION
Related #191.

This PR tweaks the functionality of the previous PR so that, when an overlay box is selected, clicking elsewhere on the certificate image deselects the box.

## Testing Instructions
- Edit a certificate template.
- Click on a box on top of the image and drag it and/or resize it.
- Click on the image, outside of the box.
- Ensure that the box is deselected and that the _Done_ text of the button in _Certificate Data_ for the appropriate box is changed back to _Set Position_.