### PR TITLE
Rename plugin to Sensei LMS Certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Sensei Certificates
-===================
+Sensei LMS Certificates
+=======================
 
 Award your students with a certificate of completion and a sense of accomplishment after finishing a course.

--- a/admin/post-types/certificate_templates.php
+++ b/admin/post-types/certificate_templates.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Sensei Certificates Templates
+ * Sensei LMS Certificates Templates
  *
  * All functionality pertaining to the Certificate Templates functionality in Sensei.
  *

--- a/admin/post-types/writepanels/writepanel-certificate_data.php
+++ b/admin/post-types/writepanels/writepanel-certificate_data.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Sensei Certificates Templates
+ * Sensei LMS Certificates Templates
  *
  * All functionality pertaining to the Certificate Templates functionality in Sensei.
  *

--- a/admin/post-types/writepanels/writepanel-certificate_image.php
+++ b/admin/post-types/writepanels/writepanel-certificate_image.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Sensei Certificates Templates
+ * Sensei LMS Certificates Templates
  *
  * All functionality pertaining to the Certificate Templates functionality in Sensei.
  *

--- a/admin/post-types/writepanels/writepanel-course_data.php
+++ b/admin/post-types/writepanels/writepanel-course_data.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Sensei Certificates Templates
+ * Sensei LMS Certificates Templates
  *
  * All functionality pertaining to the Certificate Templates functionality in Sensei.
  *

--- a/admin/post-types/writepanels/writepanels-init.php
+++ b/admin/post-types/writepanels/writepanels-init.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Sensei Certificates Templates
+ * Sensei LMS Certificates Templates
  *
  * All functionality pertaining to the Certificate Templates functionality in Sensei.
  *

--- a/admin/woothemes-sensei-certificate-templates-admin-init.php
+++ b/admin/woothemes-sensei-certificate-templates-admin-init.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Sensei Certificates Templates Admin
+ * Sensei LMS Certificates Templates Admin
  *
  * @package   woothemes-sensei-certificates/Admin
  * @author    Automattic
@@ -113,7 +113,7 @@ function sensei_certificate_template_admin_help_tab() {
 		array(
 			'id'      => 'sensei_certificate_template_overview_help_tab',
 			'title'   => __( 'Overview', 'sensei-certificates' ),
-			'content' => '<p>' . __( 'The Sensei Certificates extension allows you to create and configure customizable certificate templates which can be attached to Sensei Courses.  Your learners will earn a Certificate which they can download and share with others once they have completed a course.', 'sensei-certificates' ) . '</p>',
+			'content' => '<p>' . __( 'The Sensei LMS Certificates extension allows you to create and configure customizable certificate templates which can be attached to Sensei Courses.  Your learners will earn a Certificate which they can download and share with others once they have completed a course.', 'sensei-certificates' ) . '</p>',
 		)
 	);
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-*** Sensei Certificates Changelog ***
+*** Changelog ***
 
 2019.04.25 - version 2.0.0
 * New: Add dependency check for minimum Sensei (1.11.0) and PHP (5.6) versions - #171

--- a/classes/class-woothemes-sensei-certificate-templates.php
+++ b/classes/class-woothemes-sensei-certificate-templates.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Sensei Certificates Templates Class
+ * Sensei LMS Certificates Templates Class
  *
  * All functionality pertaining to the Certificate Templates functionality in Sensei.
  *

--- a/classes/class-woothemes-sensei-certificates-dependency-checker.php
+++ b/classes/class-woothemes-sensei-certificates-dependency-checker.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Sensei Certificates Extension Dependencies Check
+ * Sensei LMS Certificates Extension Dependencies Check
  *
  * @since 2.0.0
  */
@@ -89,7 +89,7 @@ class Woothemes_Sensei_Certificates_Dependency_Checker {
 		}
 
 		// translators: %1$s is version of PHP that this plugin requires; %2$s is the version of PHP WordPress is running on.
-		$message = sprintf( __( '<strong>Sensei Certificates</strong> requires a minimum PHP version of %1$s, but you are running %2$s.', 'sensei-certificates' ), self::MINIMUM_PHP_VERSION, phpversion() );
+		$message = sprintf( __( '<strong>Sensei LMS Certificates</strong> requires a minimum PHP version of %1$s, but you are running %2$s.', 'sensei-certificates' ), self::MINIMUM_PHP_VERSION, phpversion() );
 		echo '<div class="error"><p>';
 		echo wp_kses( $message, array( 'strong' => array() ) );
 		$php_update_url = 'https://wordpress.org/support/update-php/';
@@ -120,7 +120,7 @@ class Woothemes_Sensei_Certificates_Dependency_Checker {
 		}
 
 		// translators: %1$s is the minimum version number of Sensei that is required.
-		$message = sprintf( __( '<strong>Sensei Certificates</strong> requires that the plugin <strong>Sensei</strong> (minimum version: <strong>%1$s</strong>) is installed and activated.', 'sensei-certificates' ), self::MINIMUM_SENSEI_VERSION );
+		$message = sprintf( __( '<strong>Sensei LMS Certificates</strong> requires that the plugin <strong>Sensei</strong> (minimum version: <strong>%1$s</strong>) is installed and activated.', 'sensei-certificates' ), self::MINIMUM_SENSEI_VERSION );
 		echo '<div class="error"><p>';
 		echo wp_kses( $message, array( 'strong' => array() ) );
 		echo '</p></div>';

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Sensei Certificates Main Class
+ * Sensei LMS Certificates Main Class
  *
  * All functionality pertaining to the Certificates functionality in Sensei.
  *
@@ -1141,7 +1141,7 @@ class WooThemes_Sensei_Certificates {
 
 		if ( $this->_inline_js ) {
 
-			echo "<!-- Sensei Certificates JavaScript-->\n<script type=\"text/javascript\">\njQuery(document).ready(function($) {";
+			echo "<!-- Sensei LMS Certificates JavaScript-->\n<script type=\"text/javascript\">\njQuery(document).ready(function($) {";
 
 			// Sanitize
 			$this->_inline_js = wp_check_invalid_utf8( $this->_inline_js );

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -83,7 +83,7 @@ function pot() {
 		] )
 		.pipe( wpPot( {
 			domain: 'sensei-certificates',
-			package: 'Sensei Certificates',
+			package: 'Sensei LMS Certificates',
 		} ) )
 		.pipe( dest( 'lang/sensei-certificates.pot' ) );
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<ruleset name="Sensei Certificates">
-	<description>A custom set of code standard rules to check for the Sensei Certificates plugin.</description>
+<ruleset name="Sensei LMS Certificates">
+	<description>A custom set of code standard rules to check for the Sensei LMS Certificates plugin.</description>
 
 	<!-- For help in understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
 	<!-- For help in using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->

--- a/sensei-certificates-functions.php
+++ b/sensei-certificates-functions.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Sensei Certificates functions.
+ * Sensei LMS Certificates functions.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -22,12 +22,12 @@ function sensei_certificates_updates_list( $updates ) {
 			'sensei_update_users_certificate_data'      => array(
 				'title'   => 'Create Certificates',
 				'desc'    => 'Creates certificates for learners who have already completed Courses.',
-				'product' => 'Sensei Certificates',
+				'product' => 'Sensei LMS Certificates',
 			),
 			'sensei_create_master_certificate_template' => array(
 				'title'   => 'Create Master Certificate Template',
 				'desc'    => 'Creates the master Certificate Template for all Courses.',
-				'product' => 'Sensei Certificates',
+				'product' => 'Sensei LMS Certificates',
 			),
 		),
 	);
@@ -153,7 +153,7 @@ function sensei_create_master_certificate_template() {
 	}
 	$tmp     = download_url( $url );
 	$post_id = $post_id;
-	$desc    = __( 'Sensei Certificate Template Example', 'sensei-certificates' );
+	$desc    = __( 'Sensei LMS Certificate Template Example', 'sensei-certificates' );
 
 	// Set variables for storage
 	// fix file filename for query strings

--- a/templates/single-certificate_template.php
+++ b/templates/single-certificate_template.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Sensei Certificates Templates
+ * Sensei LMS Certificates Templates
  *
  * All functionality pertaining to the Certificate Templates functionality in Sensei.
  *

--- a/woothemes-sensei-certificates.php
+++ b/woothemes-sensei-certificates.php
@@ -6,9 +6,9 @@
  * Version: 2.0.0
  * Author: Automattic
  * Author URI: https://automattic.com
+ * Requires at least: 4.9
  * Requires PHP: 5.6
- * Requires at least: 4.1
- * Tested up to: 5.1
+ * Tested up to: 5.3
  * Woo: 247548:625ee5fe1bf36b4c741ab07507ba2ffd
  * License: GPLv2+
  */

--- a/woothemes-sensei-certificates.php
+++ b/woothemes-sensei-certificates.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: Sensei Certificates
+ * Plugin Name: Sensei LMS Certificates
  * Plugin URI: https://woocommerce.com/products/sensei-certificates/
  * Description: Award your students with a certificate of completion and a sense of accomplishment after finishing a course.
  * Version: 2.0.0


### PR DESCRIPTION
This PR renames the plugin to Sensei LMS Certificates.

## Testing Instructions
1. Go the the _Plugins_ page and ensure the plugin name is _Sensei LMS Certificates_.
2. Go to _Sensei LMS_ > _Data Updates_ and check that the _Create Certificates_ and _Create Master Certificate Template_ rows at the bottom of the screen show the updated plugin name.