### PR TITLE
Retrieve absolute image path via get_attached_file()

### DIFF
--- a/classes/class-woothemes-sensei-certificate-templates.php
+++ b/classes/class-woothemes-sensei-certificate-templates.php
@@ -446,8 +446,7 @@ class WooThemes_Sensei_Certificate_Templates {
 		}
 
 		// set the certificate image
-		$upload_dir = wp_upload_dir();
-		$fpdf->Image( $upload_dir['basedir'] . '/' . $image['file'], 0, 0, $image['width'], $image['height'] );
+		$fpdf->Image( get_attached_file( $this->get_image_id() ), 0, 0, $image['width'], $image['height'] );
 
 		// this is useful for displaying the text cell borders when debugging the PDF layout,
 		// though keep in mind that we translate the box position to align the text to bottom

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -886,14 +886,8 @@ class WooThemes_Sensei_Certificates {
 
 		// Logo image
 		if ( isset( $this->image_id ) && is_numeric( $this->image_id ) && 0 < intval( $this->image_id ) ) {
-			$image_src = wp_get_attachment_url( $this->image_id );
-
-			// Use image path instead of URL
-			$uploads   = wp_upload_dir();
-			$file_path = str_replace( $uploads['baseurl'], $uploads['basedir'], $image_src );
-
-			$pdf_certificate->bg_image_src = $file_path;
-		} // End If Statement
+            $pdf_certificate->bg_image_src = get_attached_file( $this->image_id );
+		}
 
 	} // End certificate_background()
 


### PR DESCRIPTION
This pull request would allow filtering the certificate image path to allow plugins such as Offload Media to work. See #198 