### PR TITLE
Remove unnecessary `frontend` stylesheet. 

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,7 +1,0 @@
-a.sensei-certificate-link {
-  margin-left: 5px;
-}
-
-#certificates_user_settings {
-  clear: both;
-}

--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -1,7 +1,0 @@
-a.sensei-certificate-link {
-	margin-left: 5px;
-}
-
-#certificates_user_settings {
-	clear: both;
-}

--- a/classes/class-woothemes-sensei-certificate-templates.php
+++ b/classes/class-woothemes-sensei-certificate-templates.php
@@ -23,7 +23,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * - setup_certificate_templates_post_type()
  * - post_type_custom_column_heading()
  * - post_type_custom_column_content()
- * - enqueue_styles()
  * - populate_object()
  * - get_message()
  * - get_image_id()
@@ -71,11 +70,6 @@ class WooThemes_Sensei_Certificate_Templates {
 
 		// Setup post type
 		add_action( 'init', array( $this, 'setup_certificate_templates_post_type' ), 110 );
-
-		/**
-		 * FRONTEND
-		 */
-		add_action( 'sensei_additional_styles', array( $this, 'enqueue_styles' ) );
 
 		/**
 		 * BACKEND
@@ -268,21 +262,6 @@ class WooThemes_Sensei_Certificate_Templates {
 		} // End Switch Statement
 
 	} // End post_type_custom_column_content()
-
-
-	/**
-	 * enqueue_styles loads frontend styles
-	 *
-	 * @access public
-	 * @since  1.0.0
-	 * @return void
-	 */
-	public function enqueue_styles() {
-
-		wp_register_style( $this->token . '-frontend', $this->plugin_url . 'assets/css/frontend.css', '', '1.0.0', 'screen' );
-		wp_enqueue_style( $this->token . '-frontend' );
-
-	} // End enqueue_styles()
 
 
 	/**

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -995,7 +995,7 @@ class WooThemes_Sensei_Certificates {
 
 			} // End If Statement
 
-			$message = $message . '<a href="' . $certificate_url . '" class="' . $classes . 'sensei-certificate-link" title="' . esc_attr( __( 'View Certificate', 'sensei-certificates' ) ) . '">' . __( 'View Certificate', 'sensei-certificates' ) . '</a>';
+			$message = $message . '<a href="' . $certificate_url . '" class="' . $classes . 'view-results-link" title="' . esc_attr( __( 'View Certificate', 'sensei-certificates' ) ) . '">' . __( 'View Certificate', 'sensei-certificates' ) . '</a>';
 
 		} // End If Statement
 
@@ -1080,7 +1080,7 @@ class WooThemes_Sensei_Certificates {
 
 			if ( '' != $certificate_url ) {
 
-				$output = '<a href="' . $certificate_url . '" class="sensei-certificate-link" title="' . esc_attr( __( 'View Certificate', 'sensei-certificates' ) ) . '">' . __( 'View Certificate', 'sensei-certificates' ) . '</a>';
+				$output = '<a href="' . $certificate_url . '" class="view-results-link" title="' . esc_attr( __( 'View Certificate', 'sensei-certificates' ) ) . '">' . __( 'View Certificate', 'sensei-certificates' ) . '</a>';
 
 			} // End If Statement
 

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -30,7 +30,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * - certificate_backgroudn()
  * - get_certificate_font_settings()
  * - certificate_link()
- * - enqueue_styles()
  * - create_columns()
  * - populate_columns()
  * - add_inline_js()
@@ -130,7 +129,6 @@ class WooThemes_Sensei_Certificates {
 			add_filter( 'sensei_view_results_text', array( $instance, 'certificate_link' ), 10, 1 );
 		}
 		add_filter( 'sensei_results_links', array( $instance, 'certificate_link' ), 10, 2 );
-		add_action( 'sensei_additional_styles', array( $instance, 'enqueue_styles' ) );
 		add_action( 'sensei_user_lesson_reset', array( $instance, 'reset_lesson_course_certificate' ), 10, 2 );
 		add_action( 'sensei_user_course_reset', array( $instance, 'reset_course_certificate' ), 10, 2 );
 
@@ -1043,22 +1041,6 @@ class WooThemes_Sensei_Certificates {
 		return $certificate_url;
 
 	} // End get_certificate_url()
-
-
-	/**
-	 * enqueue_styles loads frontend styles
-	 *
-	 * @access public
-	 * @since  1.0.0
-	 * @return void
-	 */
-	public function enqueue_styles() {
-
-		$this->token = 'sensei-certificates';
-		wp_register_style( $this->token . '-frontend', $this->plugin_url . 'assets/css/frontend.css', '', '1.0.0', 'screen' );
-		wp_enqueue_style( $this->token . '-frontend' );
-
-	} // End enqueue_styles()
 
 
 	/**


### PR DESCRIPTION
Fixes #186. I started doing some fancy checks for which views we should be loading the `frontend` CSS on, but quickly realized the `frontend.css` was very small and only styled two elements. I didn't see any difference if I simply deleted them:

`a.sensei-certificate-link {
  margin-left: 5px;
}
`
The left margin on the `View certificate` button doesn't seem to be necessary, as it wraps when the viewport is small anyways:

<img width="470" alt="Screen Shot 2020-02-12 at 2 41 45 PM" src="https://user-images.githubusercontent.com/789137/74380356-a23c6b80-4da6-11ea-833d-ecb869db7ff6.png">

`#certificates_user_settings {
  clear: both;
}
`
This was applied to the form for allowing a learner profile to be publicly viewable. I don't believe we need the `clear: both` here in our modern browser age!

<img width="489" alt="Screen Shot 2020-02-12 at 2 48 47 PM" src="https://user-images.githubusercontent.com/789137/74380474-e16abc80-4da6-11ea-96d9-5b1b453c451b.png">
 
#### Changes proposed in this Pull Request:

* Deletes the `frontend.css` file and removes the code that enqueues it. 

#### Testing instructions:

* Complete a course so that you receive the certificate. The `View certificate` button should look and operate normally.
* View your learner profile (You may need to enable the public learner profile setting). The `Allow my certificates to be publicly viewed` form should look and operate normally.

