### PR TITLE
Don't hide template positioning box when clicking off it

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -189,19 +189,12 @@ jQuery( function($){
 			instance: true,
 			imageWidth: imageWidth,
 			imageHeight: imageHeight,
-			persistent: true,
 			x1: coords[0],
 			y1: coords[1],
 			x2: coords[0] + coords[2],
 			y2: coords[1] + coords[3],
 			onSelectEnd: function(img, selection) { areaSelect(selection, field_name); }
 		});
-
-		// Remove image area select element when clicking elsewhere on the image.
-		$( '.imgareaselect-outer' ).click( function() {
-			removeImgAreaSelect();
-			$( '.set_position' ).val(sensei_certificate_templates_params.set_position_label);
-		} );
 
 		// scroll into viewport if needed
 		if ($(document).scrollTop() > $("img#certificate_image_0").offset().top + $("img#certificate_image_0").height() * (2/3)) {

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -211,9 +211,15 @@ jQuery( function($){
 	}
 
 	// certificate image selection made, save it to the coordinate field and show the 'remove' button
-	function areaSelect(selection, field_name) {
-		$('#_' + field_name).val(selection.x1 + ',' + selection.y1 + ',' + selection.width + ',' + selection.height);
-		$('#remove_' + field_name).show();
+	function areaSelect( selection, field_name ) {
+		// Element is being drawn if width and height are not 0.
+		if ( selection && selection.width !== 0 && selection.height !== 0 ) {
+			$( '#_' + field_name ).val( selection.x1 + ',' + selection.y1 + ',' + selection.width + ',' + selection.height );
+		} else { // Otherwise, the user has clicked somewhere on the image.
+			certificate_field_area_select( field_name );
+		}
+
+		$( '#remove_' + field_name ).show();
 	}
 
 	// position remove button clicked


### PR DESCRIPTION
Fixes #4, again.

#### Changes proposed in this Pull Request:

* This PR essentially reverts #191 and #194, which broke the ability to draw new data elements on certificate images.
* It then provides an alternate solution to fix the original issue, while still enabling new data elements to be added. The default behaviour of the imgAreaSelect jQuery plugin is to cancel the selection (i.e. remove the drawn box) when clicking elsewhere inside the image, so the solution involved first determining whether the user was drawing or just clicked, and then taking appropriate action based on that. I was not able to add a click handler to the image itself, as clicking on the image OR drawing the box both triggered that handler.

#### Testing instructions:

* Create a certificate template.
* Set a certificate image on it.
* In the _Heading Position_ section, click the _Set Position_ button.
* Draw a box on top of the certificate image.
* Click the _Done_ button and ensure the box is still there.
* In the _Heading Position_ section, click the _Remove Position_ button.
* Ensure the box is removed and then draw a new one on top of the certificate image.
* This time, click outside the box but still on the image.
* Ensure the box is still there and the _Done_ button is replaced with _Set Position_.
* Click on the box you just drew. Move it or resize it and then click outside the box but still on the image.
* Ensure that the position/size of the box is be preserved and that the _Done_ button is replaced with _Set Position_.
* Repeat the above for a couple of the other elements (message, course etc.).
* Save the template and refresh the page.
* Ensure the boxes are still there.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
#### Screenshot / Video



<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
