### PR TITLE
Add front-end CSS needed to style "View Certificate" button

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,0 +1,3 @@
+.sensei-certificate-link {
+  float: right;
+}

--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -1,0 +1,3 @@
+.sensei-certificate-link {
+	float: right;
+}

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -122,19 +122,23 @@ class WooThemes_Sensei_Certificates {
 		/**
 		 * FRONTEND
 		 */
+
+		// Filters
 		add_filter( 'sensei_user_course_status_passed', array( $instance, 'certificate_link' ), 10, 1 );
 
 		// Remove in future version
 		if ( version_compare( Sensei()->version, '1.6', '<' ) ) {
 			add_filter( 'sensei_view_results_text', array( $instance, 'certificate_link' ), 10, 1 );
 		}
+
 		add_filter( 'sensei_results_links', array( $instance, 'certificate_link' ), 10, 2 );
+
+		// Actions
+		add_action( 'wp_enqueue_scripts', array( $instance, 'enqueue_styles' ) );
 		add_action( 'sensei_user_lesson_reset', array( $instance, 'reset_lesson_course_certificate' ), 10, 2 );
 		add_action( 'sensei_user_course_reset', array( $instance, 'reset_course_certificate' ), 10, 2 );
-
 		// Create certificate endpoint and handle generation of pdf certificate
 		add_action( 'template_redirect', array( $instance, 'download_certificate' ) );
-
 		// User settings output and save handling
 		add_action( 'sensei_learner_profile_info', array( $instance, 'certificates_user_settings_form' ), 10, 1 );
 		add_action( 'sensei_complete_course', array( $instance, 'certificates_user_settings_save' ), 10 );
@@ -200,6 +204,41 @@ class WooThemes_Sensei_Certificates {
 	 */
 	public static function load_textdomain() {
 		load_plugin_textdomain( 'sensei-certificates', false, dirname( SENSEI_CERTIFICATES_PLUGIN_BASENAME ) . '/lang/' );
+	}
+
+	/**
+	 * Load front-end CSS.
+	 *
+	 * @access public
+	 * @since  1.0.0
+	 */
+	public function enqueue_styles() {
+		global $wp_query;
+
+		$view_link_courses = Sensei()->settings->settings['certificates_view_courses'];
+		$view_link_profile = Sensei()->settings->settings['certificates_view_profile'];
+
+		// Certificates are not configured to display on any pages.
+		if ( ! $view_link_courses && ! $view_link_profile ) {
+			return;
+		}
+
+		$should_enqueue = false;
+
+		// My Courses or single course page.
+		if ( $view_link_courses
+			&& ( is_page( intval( Sensei()->settings->get( 'my_course_page' ) ) )
+			|| ( is_single() && 'course' === get_post_type() ) )
+		) {
+			$should_enqueue = true;
+		} else if ( $view_link_profile && isset( $wp_query->query_vars['learner_profile'] )
+		) {
+			$should_enqueue = true;
+		}
+
+		if ( $should_enqueue ) {
+			wp_enqueue_style( 'sensei-certificates-frontend', $this->plugin_url . 'assets/css/frontend.css', array(), SENSEI_CERTIFICATES_VERSION, 'screen' );
+		}
 	}
 
 	/**
@@ -995,7 +1034,7 @@ class WooThemes_Sensei_Certificates {
 
 			} // End If Statement
 
-			$message = $message . '<a href="' . $certificate_url . '" class="' . $classes . 'view-results-link" title="' . esc_attr( __( 'View Certificate', 'sensei-certificates' ) ) . '">' . __( 'View Certificate', 'sensei-certificates' ) . '</a>';
+			$message = $message . '<a href="' . $certificate_url . '" class="' . $classes . 'sensei-certificate-link" title="' . esc_attr( __( 'View Certificate', 'sensei-certificates' ) ) . '">' . __( 'View Certificate', 'sensei-certificates' ) . '</a>';
 
 		} // End If Statement
 
@@ -1080,7 +1119,7 @@ class WooThemes_Sensei_Certificates {
 
 			if ( '' != $certificate_url ) {
 
-				$output = '<a href="' . $certificate_url . '" class="view-results-link" title="' . esc_attr( __( 'View Certificate', 'sensei-certificates' ) ) . '">' . __( 'View Certificate', 'sensei-certificates' ) . '</a>';
+				$output = '<a href="' . $certificate_url . '" class="sensei-certificate-link" title="' . esc_attr( __( 'View Certificate', 'sensei-certificates' ) ) . '">' . __( 'View Certificate', 'sensei-certificates' ) . '</a>';
 
 			} // End If Statement
 

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -209,7 +209,7 @@ class WooThemes_Sensei_Certificates {
 	/**
 	 * Load front-end CSS.
 	 *
-	 * @access public
+	 * @access private
 	 * @since  1.0.0
 	 */
 	public function enqueue_styles() {


### PR DESCRIPTION
Fixes #186 in a different way.

#### Changes proposed in this Pull Request:

* This PR essentially reverts #203. I realized too late that we can't remove the `sensei-certificate-link` CSS class as third party devs could be using it. It's also not entirely appropriate to use a class named `view-results-link` on a button that is not the _View Results_ button. 
* Instead, this PR adds the front-end CSS file back. The CSS needed to style the _View Certificate_ button is minimal, given that Sensei core handles the majority of the styling [here](https://github.com/Automattic/sensei/blob/master/assets/css/frontend/sensei.scss#L895).

#### Testing instructions:

* To ensure that styling is not picked up from Sensei core, remove `a.sensei-certificate-link` from `sensei.scss` in Sensei LMS and rebuild the CSS.
* In _Certificate Settings_, ensure _View in Courses_ and _View in Learner Profile_ settings are enabled.
* Complete a course so that a certificate is generated.
* Visit the _My Courses_, single course and learner profile pages (both options in _Learner Profiles_ settings should be enabled for this). Ensure that `frontend.css` is loaded on each of these pages and that the _View Certificate_ button is styled.
* Visit other pages on your site and ensure that `frontend.css` is **not** loaded.
* Uncheck the _View in Courses_ and _View in Learner Profile_ settings.
* Visit the _My Courses_, single course and learner profile pages. Ensure that `frontend.css` is **not** loaded.