### PR TITLE
Localize placeholder text when editing certificate template

### DIFF
--- a/admin/woothemes-sensei-certificate-templates-admin-init.php
+++ b/admin/woothemes-sensei-certificate-templates-admin-init.php
@@ -237,11 +237,16 @@ function sensei_certificate_template_admin_enqueue_scripts() {
 
 			// pass parameters into the javascript file
 			$sensei_certificate_templates_params = array(
-				'done_label'           => __( 'Done', 'sensei-certificates' ),
-				'set_position_label'   => __( 'Set Position', 'sensei-certificates' ),
-				'post_id'              => $post->ID,
-				'primary_image_width'  => isset( $attachment['width'] ) && $attachment['width'] ? $attachment['width'] : '0',
-				'primary_image_height' => isset( $attachment['height'] ) && $attachment['height'] ? $attachment['height'] : '0',
+				'_certificate_heading_pos'    => __( 'Heading', 'sensei-certificates' ),
+				'_certificate_message_pos'    => __( 'Message', 'sensei-certificates' ),
+				'_certificate_course_pos'     => __( 'Course', 'sensei-certificates' ),
+				'_certificate_completion_pos' => __( 'Completion Date', 'sensei-certificates' ),
+				'_certificate_place_pos'      => __( 'Place', 'sensei-certificates' ),
+				'done_label'                  => __( 'Done', 'sensei-certificates' ),
+				'set_position_label'          => __( 'Set Position', 'sensei-certificates' ),
+				'post_id'                     => $post->ID,
+				'primary_image_width'         => isset( $attachment['width'] ) && $attachment['width'] ? $attachment['width'] : '0',
+				'primary_image_height'        => isset( $attachment['height'] ) && $attachment['height'] ? $attachment['height'] : '0',
 			);
 
 		} // End If Statement

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -95,7 +95,9 @@ jQuery( function($){
 	function redrawCertificateFieldPlaceholders() {
 		$('.field_pos').each(function(index,el) {
 			el = $(el);
-			var field = $('#field'+el.attr('id'));
+
+			var id = el.attr( 'id' );
+			var field = $( '#field' + id );
 			var image = $('#certificate_image_0');
 
 			// if the image is removed, hide all fields
@@ -114,17 +116,17 @@ jQuery( function($){
 			var position = el.val() ? el.val().split(',').map(function(n) { return parseInt(n) * scale }) : null;
 
 			// create the field element if needed
-			if (0 == field.length) {
-				var name = el.prev().find('label').html();
-				name = name.substr(0, name.length - 9);
-				$('#certificate_image_wrapper').append('<span id="field'+el.attr('id')+'" class="certificate_field" style="display:none;">'+name+'</span>');
+			if ( 0 === field.length ) {
+				$( '#certificate_image_wrapper' ).append( '<span id="field' + id
+					+ '" class="certificate_field" style="display:none;">'
+					+ sensei_certificate_templates_params[id] + '</span>' );
 
 				// clicking on the fields allows them to be edited
-				$('#field'+el.attr('id')).click( function(el) {
+				$( '#field' + id ).click( function(el) {
 					certificate_field_area_select(el.target.id.substr(6));  // remove the leading 'field_' to create the field name
 				});
 
-				field = $('#field'+el.attr('id'));
+				field = $( '#field'+ id );
 			}
 
 			if (position) {


### PR DESCRIPTION
Fixes #178.

#### Changes proposed in this Pull Request:
This fixes placeholder text being truncated when editing a certificate template. Previously, the label was being used (e.g. _Heading Position_, _Message Position_ etc.) as a starting point, and then truncated to remove the word _Position_ before showing it on the overlay. This is obviously not an i18n-friendly solution.

This PR localizes these strings and passes them for use in the JS. The ID of the associated field is used to map localized strings to the appropriate placeholder.

#### Testing instructions:

- Go to _Certificates_ > _Certificate Templates_ and select a template.
- Add a _Course_ placeholder if one is not already there (can be added by clicking the _Set Position_ button next to _Course Position_ in the _Certificate Data_ meta box, then drawing a box on top of the image and clicking _Done_.
- Save the template.
- Change the _Site Language_ setting in _Settings_ > _General_ to Hungarian (Magyar).
- Click the _Update translations_ button on the _Dashboard_ > _Updates_ page (of course, this will be called something else in Hungarian).
- Ensure the placeholder text says "Tanfolyam" and not "Tanfolya".
- Note that the other placeholder text are new translations so they will appear in English until we receive new translation files.