### PR TITLE
Prepare the plugin to WordPress.org

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,7 +26,7 @@ function cssMinify() {
 }
 
 function docs() {
-	return src( [ 'changelog.txt', 'README.md' ] )
+	return src( [ 'changelog.txt', 'readme.txt' ] )
 		.pipe( dest( buildDir ) )
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,63 @@
+=== Sensei LMS Certificates ===
+Contributors: automattic, alexsanford1, donnapep, jakeom, gkaragia, renatho, yscik
+Tags: certificates, course certificate, sensei lms
+Requires at least: 4.9
+Tested up to: 5.3
+Requires PHP: 5.6
+Stable tag: 2.0.2
+License: GPLv2+
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+
+Award your students with a certificate of completion and a sense of accomplishment after finishing a course.
+
+== Description ==
+
+= Award your students with a certificate of completion for their completed courses. =
+
+There’s no feeling quite like it. You’ve studied hard, taken your test and passed (with flying colours, I’m sure)! After all that effort, you’re finally at the end of the course. You want to share this accolade with everyone. Print out your certificate!
+
+With Sensei LMS Certificates, your students are awarded a certificate for each course they complete through your online school. These certificates can be downloaded, printed and framed on their office wall, or stuck up on the fridge for the entire family to enjoy. If you’d like to make certificates public for all to view, that’s available as well.
+
+= Customise the certificate design =
+
+Sensei LMS Certificates includes an advanced certificate design system. Through this system, you can upload your own background image, place and style the size, typeface and colour of the various pieces of text on the certificate and truly create a unique design best suited to your online school.
+
+If you don’t fancy yourself as a designer, or would prefer to get up and running in not much time, Sensei LMS Certificates includes a stylish default certificate design, suited to any genre of online school.
+
+= We already have many students who have completed courses! Can they get certificates as well? =
+
+They certainly can! When activating Sensei LMS Certificates, you will be prompted to generate certificates for each student who has already completed a course. Thankfully, this can be done, for all students, with the click of a button.
+
+= Increase student retention =
+
+We all enjoy receiving rewards. If your students complete a single course, and receive their certificate for the hard work they’ve done, they will be statistically more likely to continue on to a further course, in order to re-live the rewarding experience of receiving a certificate for their efforts.
+
+We look forward to seeing your students light up with excitement when they receive their certificates for all the hard work they’ve done in completing your courses.
+
+= Key Features =
+
+* Easily-customised certificate design
+* Lean code, to ensure a pleasant experience
+* Intuitive integration with Sensei
+
+== Installation ==
+
+= Automatic installation =
+
+1. Log into your WordPress admin panel and go to *Plugins* > *Add New*.
+2. Enter "Sensei LMS Certificates" into the search field.
+3. Once you've located the plugin, click *Install Now*.
+4. Click *Activate*.
+
+= Manual installation =
+
+1. Download the plugin file to your computer and unzip it.
+2. Using an FTP program, or your hosting control panel, upload the unzipped plugin folder to your WordPress installation's `wp-content/plugins/` directory on the server.
+3. Log into your WordPress admin panel and activate the plugin from the *Plugins* menu.
+
+== Screenshots ==
+1. Certificate of completion
+2. Customise the certificate design
+
+== Changelog ==
+[See changelog for all versions](https://raw.githubusercontent.com/woocommerce/sensei-certificates/master/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -38,7 +38,7 @@ We look forward to seeing your students light up with excitement when they recei
 
 * Easily-customised certificate design
 * Lean code, to ensure a pleasant experience
-* Intuitive integration with Sensei
+* Intuitive integration with Sensei LMS
 
 == Installation ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, alexsanford1, donnapep, jakeom, gkaragia, renatho, yscik
 Tags: certificates, course certificate, sensei lms
 Requires at least: 4.9
-Tested up to: 5.3
+Tested up to: 5.4
 Requires PHP: 5.6
 Stable tag: 2.0.2
 License: GPLv2+

--- a/woothemes-sensei-certificates.php
+++ b/woothemes-sensei-certificates.php
@@ -9,7 +9,6 @@
  * Requires at least: 4.9
  * Requires PHP: 5.6
  * Tested up to: 5.3
- * Woo: 247548:625ee5fe1bf36b4c741ab07507ba2ffd
  * License: GPLv2+
  */
 

--- a/woothemes-sensei-certificates.php
+++ b/woothemes-sensei-certificates.php
@@ -8,7 +8,7 @@
  * Author URI: https://automattic.com
  * Requires at least: 4.9
  * Requires PHP: 5.6
- * Tested up to: 5.3
+ * Tested up to: 5.4
  * License: GPLv2+
  */
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Add `readme.txt`.
* Bump tested up to.
* Remove Woo header.

#### Testing instructions:

To confirm it's working in the WP 5.4.

* Add and active the Sensei LMS Certificates plugin in the WP 5.4.
* Create a course with some lessons.
* Complete all the lessons.
* Go to the course page and confirm that the certificate button is appearing and opening the certificate.
* Also navigate in the wp-admin / certificates to make sure that all is working properly.