### PR TITLE
Fix dropdown in Certificate Template meta box

### DIFF
--- a/assets/js/course.js
+++ b/assets/js/course.js
@@ -1,4 +1,4 @@
 jQuery(document).ready( function($) {
 	// Course Write Panel
-	if ( jQuery( '#course-certificate-template-options' ) ) { jQuery( '#course-certificate-template-options' ).select2(); }
+	if ( jQuery( '#course-certificate-template-options' ) ) { jQuery( '#course-certificate-template-options' ).select2({width: '100%'}); }
 });

--- a/assets/js/course.js
+++ b/assets/js/course.js
@@ -1,4 +1,4 @@
 jQuery(document).ready( function($) {
 	// Course Write Panel
-	if ( jQuery( '#course-certificate-template-options' ) ) { jQuery( '#course-certificate-template-options' ).select2({width: '100%'}); }
+	if ( jQuery( '#course-certificate-template-options' ) ) { jQuery( '#course-certificate-template-options' ).select2( { width: '100%' } ); }
 });


### PR DESCRIPTION
Fixes a dropdown. Same as https://github.com/Automattic/sensei/pull/3223.

### Testing instructions

* Edit a course
* Course Template meta box on the sidebar should look right.

### Screenshot / Video

<img width="294" alt="Screenshot 2020-05-29 at 22 45 46" src="https://user-images.githubusercontent.com/176949/83303880-269fe680-a1fe-11ea-8915-aad551ca799d.png">
