### PR TITLE
Fix New Certificate Template page on WP 5.5

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -15,7 +15,7 @@ jQuery( function($){
 	var imageWidth  = sensei_certificate_templates_params.primary_image_width;
 	var imageHeight = sensei_certificate_templates_params.primary_image_height;
 
-	$('#set-certificate-image, #set-additional-image, #add-alternative-certificate-image').live('click', function(event){
+	$( document ).on( 'click', '#set-certificate-image, #set-additional-image, #add-alternative-certificate-image', function( event ) {
 
 		event.preventDefault();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
     },
     "ansi-colors": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
       "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
       "dev": true,
       "requires": {
@@ -3194,7 +3194,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
@@ -3568,7 +3568,7 @@
     },
     "next-tick": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
@@ -3855,7 +3855,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
@@ -3966,7 +3966,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -4088,7 +4088,7 @@
         },
         "kind-of": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
           "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
           "dev": true
         }
@@ -5523,7 +5523,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {


### PR DESCRIPTION
Fixes #236

### Changes proposed in this Pull Request

* Remove usage of deprecated `.live()` function (removed in WP 5.5) in favour of `.on()`.

### Testing instructions

1. Go to Sensei LMS->Certificates->Certificate Templates
1. Click on "Add New Certificate Template"
1. Click on "Set Certificate Image" - this should open up the Media Library to select an image.
1. Afterward (or on an existing template), click on "Remove certificate image". Ensure that the image is removed.

### Note

I was unable to do any testing for elements with the selectors `#set-additional-image` and `#add-alternative-certificate-image`, because they don't appear to exist. I [created an issue](https://github.com/woocommerce/sensei-certificates/issues/237) to explore this, because I don't want it to distract from the current fix.