### PR TITLE
Allow newlines in text fields within Certificate Templates

### DIFF
--- a/admin/post-types/writepanels/writepanel-certificate_data.php
+++ b/admin/post-types/writepanels/writepanel-certificate_data.php
@@ -385,7 +385,7 @@ function certificate_templates_process_meta( $post_id, $post ) {
 		}
 
 		if ( ! empty( $_POST[ $field_name . '_text' ] ) ) {
-			$field['text'] = sanitize_text_field( wp_unslash( $_POST[ $field_name . '_text' ] ) );
+			$field['text'] = sanitize_textarea_field( wp_unslash( $_POST[ $field_name . '_text' ] ) );
 		}
 
 		// Get the field font settings (if any).


### PR DESCRIPTION
Fixes #235

### Changes proposed in this Pull Request

Switches sanitization for "text" fields in Certificate Templates to use `sanitize_textarea_field` instead of `sanitize_text_field`, which preserves newlines.

NOTE: This is actually only needed for the "Message Text" area (which is a `textarea` field), but this implementation, for the sake of simplicity, changes it across all "text" fields on the page. This means that newlines will be allowed in all of those fields. This seems harmless, but we could implement this as a special case instead, if we feel that allowing newlines in the other fields may be dangerous.

### Testing instructions

- Edit or create a Certificate Template.
- Update the "Message Text" field and include newlines.
- Save the template and reload.
- Ensure the "Message Text" field still has newlines.