### PR TITLE
Don't encode course title for html display in PDF generation

### DIFF
--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -746,7 +746,7 @@ class WooThemes_Sensei_Certificates {
 
 			// Get Course Data
 			$course_id       = get_post_meta( $certificate_id, 'course_id', true );
-			$course_title    = get_the_title( $course_id );
+			$course_title    = get_post_field('post_title', $course_id);
 			$course_end      = Sensei_Utils::sensei_check_for_activity(
 				array(
 					'post_id' => intval( $course_id ),


### PR DESCRIPTION
Fixes #227

### Changes proposed in this Pull Request

* Use raw title in PDF output

### Testing instructions

* Set a certificate template for the course - the default `Example template` is fine
* Update a course with a title with special characters
* Finish the course with a user
* Access the certificate in `My courses` > `View Certificate`
* Make sure the course title is displayed correctly

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

![image](https://user-images.githubusercontent.com/176949/92251475-3568fa00-eecd-11ea-9e40-7e21f3976d22.png)

