### PR TITLE
Introduce new tools to replace data updates

### DIFF
--- a/classes/background-jobs/class-sensei-certificates-create-certificates.php
+++ b/classes/background-jobs/class-sensei-certificates-create-certificates.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * File containing the class Sensei_Certificates_Create_Certificates.
+ *
+ * @package sensei-certificates
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * The Sensei_Certificates_Create_Certificates handles creating missing certificates for learners who have completed
+ * courses.
+ */
+class Sensei_Certificates_Create_Certificates implements Sensei_Background_Job_Interface {
+	const NAME            = 'sensei_certificates_create_certificates';
+	const BATCH_SIZE      = 5;
+	const STATE_TRANSIENT = 'sensei_certificates_job_create_certificates';
+
+	/**
+	 * Whether the job is complete.
+	 *
+	 * @var bool
+	 */
+	private $is_complete = false;
+
+	/**
+	 * Singleton instance.
+	 *
+	 * @var self
+	 */
+	private static $instance;
+
+	/**
+	 * Sensei_Certificates_Create_Certificates constructor.
+	 */
+	private function __construct() {}
+
+	/**
+	 * Get singleton instance of class.
+	 *
+	 * @return Sensei_Certificates_Create_Certificates
+	 */
+	public static function instance() {
+		if ( ! isset( self::$instance ) ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Get the action name for the scheduled job.
+	 *
+	 * @return string
+	 */
+	public function get_name() {
+		return self::NAME;
+	}
+
+	/**
+	 * Get the arguments to run with the job.
+	 *
+	 * @return array
+	 */
+	public function get_args() {
+		return array();
+	}
+
+	/**
+	 * Run the job.
+	 */
+	public function run() {
+		$offset = $this->get_offset();
+
+		if ( ! sensei_update_users_certificate_data( self::BATCH_SIZE, $offset ) ) {
+			$this->set_offset( $offset + self::BATCH_SIZE );
+		} else {
+			$this->end();
+		}
+	}
+
+	/**
+	 * After the job runs, check to see if it needs to be re-queued for the next batch.
+	 *
+	 * @return bool
+	 */
+	public function is_complete() {
+		return $this->is_complete;
+	}
+
+	/**
+	 * Set up the job.
+	 */
+	public function setup() {
+		$this->set_offset( 0 );
+	}
+
+	/**
+	 * Clean up when a job is finished or has been cancelled.
+	 */
+	public function end() {
+		$this->delete_state();
+		$this->is_complete = true;
+	}
+
+	/**
+	 * Get the progress of the job.
+	 *
+	 * @return false|float
+	 */
+	public function get_progress() {
+		if ( ! $this->has_state() ) {
+			return false;
+		}
+
+		$user_count  = count_users();
+		$total_users = $user_count['total_users'];
+		$done        = min( $this->get_offset(), $user_count );
+
+		return round( ( $done / $total_users ) * 100 );
+	}
+
+	/**
+	 * Is the job currently running?
+	 *
+	 * @return bool True if job is running.
+	 */
+	public function is_running() {
+		return false !== $this->has_state();
+	}
+
+	/**
+	 * Set the offset.
+	 *
+	 * @param int $offset Offset for job.
+	 */
+	private function set_offset( $offset ) {
+		$state           = $this->get_state();
+		$state['offset'] = (int) $offset;
+
+		$this->save_state( $state );
+	}
+
+	/**
+	 * Get the offset.
+	 *
+	 * @return int
+	 */
+	private function get_offset() {
+		$state = $this->get_state();
+
+		return (int) $state['offset'];
+	}
+
+	/**
+	 * Get the state of the job.
+	 */
+	private function get_state() {
+		$state = get_transient( self::STATE_TRANSIENT );
+
+		$default_state = array(
+			'offset' => 0,
+		);
+
+		if ( $state ) {
+			return array_merge( $default_state, (array) $state );
+		}
+
+		return $default_state;
+	}
+
+	/**
+	 * Set the state for the job.
+	 *
+	 * @param array $state State to set.
+	 */
+	private function save_state( $state ) {
+		set_transient( self::STATE_TRANSIENT, $state, HOUR_IN_SECONDS );
+	}
+
+	/**
+	 * Delete the state and end the job.
+	 */
+	private function delete_state() {
+		delete_transient( self::STATE_TRANSIENT );
+	}
+
+	/**
+	 * Check if the job has been started and state is set.
+	 */
+	private function has_state() {
+		$state = get_transient( self::STATE_TRANSIENT );
+
+		return false !== $state;
+	}
+}

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -213,6 +213,7 @@ class WooThemes_Sensei_Certificates {
 	 */
 	private static function load_tools() {
 		require_once __DIR__ . '/tools/class-sensei-certificates-tool-create-certificates.php';
+		require_once __DIR__ . '/tools/class-sensei-certificates-tool-create-default-example-template.php';
 
 		add_filter( 'sensei_tools', [ __CLASS__, 'add_sensei_certificates_tools' ] );
 	}
@@ -226,6 +227,7 @@ class WooThemes_Sensei_Certificates {
 	 */
 	public static function add_sensei_certificates_tools( $tools ) {
 		$tools[] = new Sensei_Certificates_Tool_Create_Certificates();
+		$tools[] = new Sensei_Certificates_Tool_Create_Default_Example_Template();
 
 		return $tools;
 	}

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -160,6 +160,14 @@ class WooThemes_Sensei_Certificates {
 			// Reorder the admin menus to display Certificates below Lessons.
 			add_filter( 'custom_menu_order', '__return_true', 20 );
 			add_filter( 'menu_order', array( $instance, 'admin_menu_order' ) );
+
+			if ( interface_exists( 'Sensei_Tool_Interface' ) ) {
+				self::load_tools();
+			}
+		}
+
+		if ( interface_exists( 'Sensei_Background_Job_Interface' ) ) {
+			self::load_background_jobs();
 		}
 
 		// Generate certificate hash when course is completed.
@@ -179,6 +187,47 @@ class WooThemes_Sensei_Certificates {
 		require_once dirname( __FILE__ ) . '/class-woothemes-sensei-certificates.php';
 		require_once dirname( __FILE__ ) . '/class-woothemes-sensei-certificate-templates.php';
 		require_once dirname( __FILE__ ) . '/class-woothemes-sensei-certificates-data-store.php';
+	}
+
+	/**
+	 * Load background jobs.
+	 */
+	private static function load_background_jobs() {
+		require_once __DIR__ . '/background-jobs/class-sensei-certificates-create-certificates.php';
+
+		add_action( Sensei_Certificates_Create_Certificates::NAME, [ __CLASS__, 'run_create_certificates_job' ] );
+	}
+
+	/**
+	 * Run the create certificates job.
+	 *
+	 * @access private
+	 */
+	public static function run_create_certificates_job() {
+		$job = Sensei_Certificates_Create_Certificates::instance();
+		Sensei_Scheduler::instance()->run( $job );
+	}
+
+	/**
+	 * Load the tools and add needed filters.
+	 */
+	private static function load_tools() {
+		require_once __DIR__ . '/tools/class-sensei-certificates-tool-create-certificates.php';
+
+		add_filter( 'sensei_tools', [ __CLASS__, 'add_sensei_certificates_tools' ] );
+	}
+
+	/**
+	 * Add Sensei Certificates tools to Sensei LMS.
+	 *
+	 * @param array $tools Tool objects for Sensei LMS.
+	 *
+	 * @return array
+	 */
+	public static function add_sensei_certificates_tools( $tools ) {
+		$tools[] = new Sensei_Certificates_Tool_Create_Certificates();
+
+		return $tools;
 	}
 
 	/**

--- a/classes/tools/class-sensei-certificates-tool-create-certificates.php
+++ b/classes/tools/class-sensei-certificates-tool-create-certificates.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * File containing Sensei_Certificates_Tool_Create_Certificates class.
+ *
+ * @package sensei-certificates
+ * @since 2.1.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Sensei_Certificates_Tool_Create_Certificates class.
+ *
+ * @since 2.1.0
+ */
+class Sensei_Certificates_Tool_Create_Certificates implements Sensei_Tool_Interface {
+	/**
+	 * Job object.
+	 *
+	 * @var Sensei_Certificates_Create_Certificates
+	 */
+	private $job;
+
+	/**
+	 * Sensei_Certificates_Tool_Create_Certificates constructor.
+	 */
+	public function __construct() {
+		$this->job = Sensei_Certificates_Create_Certificates::instance();
+
+		add_action( 'sensei_tools_listing_after_' . $this->get_id(), array( $this, 'add_status_notice' ) );
+	}
+
+	/**
+	 * Get the ID of the tool.
+	 *
+	 * @return string
+	 */
+	public function get_id() {
+		return 'sensei-certificates-create-certificates';
+	}
+
+	/**
+	 * Get the name of the tool.
+	 *
+	 * @return string
+	 */
+	public function get_name() {
+		return __( 'Create certificates', 'sensei-certificates' );
+	}
+
+	/**
+	 * Get the description of the tool.
+	 *
+	 * @return string
+	 */
+	public function get_description() {
+		return __( 'Creates certificates for learners who have already completed Courses.', 'sensei-certificates' );
+	}
+
+	/**
+	 * Run the tool.
+	 */
+	public function process() {
+		$this->job->setup();
+
+		Sensei_Scheduler::instance()->schedule_job( $this->job );
+		Sensei_Tools::instance()->add_user_message( __( 'Certificate records will be created in the background.', 'sensei-certificates' ) );
+	}
+
+	/**
+	 * Is the tool currently available?
+	 *
+	 * @return bool True if tool is available.
+	 */
+	public function is_available() {
+		return ! $this->job->is_running();
+	}
+
+	/**
+	 * Add the status notice when running.
+	 */
+	public function add_status_notice() {
+		if ( ! $this->job->is_running() ) {
+			return;
+		}
+
+		echo '<div class="notice inline notice-info"><p>';
+		// translators: Placeholder %d is the percentage complete.
+		echo esc_html( sprintf( __( 'This task is running in the background and is %d%% complete.', 'sensei-certificates' ), $this->job->get_progress() ) );
+		echo '</p></div>';
+	}
+}

--- a/classes/tools/class-sensei-certificates-tool-create-default-example-template.php
+++ b/classes/tools/class-sensei-certificates-tool-create-default-example-template.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * File containing Sensei_Certificates_Tool_Create_Default_Example_Template class.
+ *
+ * @package sensei-certificates
+ * @since 2.1.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Sensei_Certificates_Tool_Create_Default_Example_Template class.
+ *
+ * @since 2.1.0
+ */
+class Sensei_Certificates_Tool_Create_Default_Example_Template implements Sensei_Tool_Interface {
+	/**
+	 * Get the ID of the tool.
+	 *
+	 * @return string
+	 */
+	public function get_id() {
+		return 'sensei-certificates-create-default-example-template';
+	}
+
+	/**
+	 * Get the name of the tool.
+	 *
+	 * @return string
+	 */
+	public function get_name() {
+		return __( 'Create default example certificate template', 'sensei-certificates' );
+	}
+
+	/**
+	 * Get the description of the tool.
+	 *
+	 * @return string
+	 */
+	public function get_description() {
+		return __( 'Recreates the example certificate template and sets all courses to use it.', 'sensei-certificates' );
+	}
+
+	/**
+	 * Run the tool.
+	 */
+	public function process() {
+		sensei_create_master_certificate_template();
+
+		Sensei_Tools::instance()->add_user_message( __( 'Example certificate template has been created and all courses have been set to use it.', 'sensei-certificates' ) );
+	}
+
+	/**
+	 * Is the tool currently available?
+	 *
+	 * @return bool True if tool is available.
+	 */
+	public function is_available() {
+		return true;
+	}
+}


### PR DESCRIPTION
For Sensei LMS 3.7 compatibility, this introduces two new tools that recreate the functionality from the legacy data updates. These tools were in data updates before.

### Changes proposed in this Pull Request

* `Create default example certificate template`: Recreates the example certificate template and sets all courses to use it. This used to be called `Create Master Certificate Template`.
* `Create certificates`: Background job that creates certificate records for all previous course completions.

### Testing instructions

Some functionality relies on https://github.com/Automattic/sensei/pull/3896, but it should still work based on current beta 1 of Sensei LMS 3.7.

* Try running both tools. 