### PR TITLE
Add View Certificate variation block

### DIFF
--- a/assets/blocks/view-certificate-block/index.js
+++ b/assets/blocks/view-certificate-block/index.js
@@ -6,18 +6,19 @@ import { registerBlockVariation } from '@wordpress/blocks';
 
 const buttonVariationAttributes = {
 	url: '/course/sensei-view-certificate',
-	title: __( 'View Certificate', 'sensei-certificates' ),
 	text: __( 'View Certificate', 'sensei-certificates' ),
 	linkTarget: '_blank'
 };
 
 registerBlockVariation( 'core/button', {
-	name: 'view-certificate-button',
+	name: 'sensei-certificates/view-certificate-button',
+	title: __( 'View Certificate', 'sensei-certificates' ),
+	description: __( 'Allow a user to view the course certificate.', 'sensei-certificates' ),
 	attributes: buttonVariationAttributes
 } );
 
 registerBlockVariation( 'core/buttons', {
-	name: 'sensei-lms/view-certificate-buttons',
+	name: 'sensei-certificates//view-certificate-buttons',
 	category: 'sensei-lms',
 	description: __( 'Allow a user to view the course certificate. The block is not displayed if the user does not have a certificate.', 'sensei-certificates' ),
 	title: __( 'View Certificate Button', 'sensei-certificates' ),

--- a/assets/blocks/view-certificate-block/index.js
+++ b/assets/blocks/view-certificate-block/index.js
@@ -1,0 +1,31 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { registerBlockVariation } from '@wordpress/blocks';
+
+const buttonVariationAttributes = {
+	url: '/course/sensei-view-certificate',
+	title: __( 'View Certificate', 'sensei-certificates' ),
+	text: __( 'View Certificate', 'sensei-certificates' ),
+	linkTarget: '_blank'
+};
+
+registerBlockVariation( 'core/button', {
+	name: 'view-certificate-button',
+	attributes: buttonVariationAttributes
+} );
+
+registerBlockVariation( 'core/buttons', {
+	name: 'sensei-lms/view-certificate-buttons',
+	category: 'sensei-lms',
+	description: __( 'Allow a user to view the course certificate. The block is not displayed if the user does not have a certificate.', 'sensei-certificates' ),
+	title: __( 'View Certificate Button', 'sensei-certificates' ),
+	example: undefined,
+	innerBlocks: [
+		{
+			name: 'core/button',
+			attributes: buttonVariationAttributes
+		}
+	],
+} );

--- a/assets/blocks/view-certificate-block/index.js
+++ b/assets/blocks/view-certificate-block/index.js
@@ -18,7 +18,7 @@ registerBlockVariation( 'core/button', {
 } );
 
 registerBlockVariation( 'core/buttons', {
-	name: 'sensei-certificates//view-certificate-buttons',
+	name: 'sensei-certificates/view-certificate-buttons',
 	category: 'sensei-lms',
 	description: __( 'Allow a user to view the course certificate. The block is not displayed if the user does not have a certificate.', 'sensei-certificates' ),
 	title: __( 'View Certificate Button', 'sensei-certificates' ),

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -191,7 +191,7 @@ class WooThemes_Sensei_Certificates {
 		$screen = get_current_screen();
 
 		if ( $screen && $screen->is_block_editor && 'course' === $screen->post_type ) {
-			wp_enqueue_script( 'sensei_certificate_course_block', $this->plugin_url . 'assets/dist/blocks/view-certificate-block.js' );
+			wp_enqueue_script( 'sensei_certificate_course_block', $this->plugin_url . 'assets/dist/blocks/view-certificate-block.js', array( 'wp-blocks', 'wp-i18n' ) );
 		}
 	}
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,7 @@ const path = require( 'path' );
 const files = {
 	'js/admin': 'js/admin.js',
 	'js/course': 'js/course.js',
+	'blocks/view-certificate-block': 'blocks/view-certificate-block/index.js',
 	'css/admin': 'css/admin.scss',
 	'css/frontend': 'css/frontend.scss',
 };


### PR DESCRIPTION
Fixes #261 

### Overview
This PR adds a block which allows users to access their certificate in the course page.

Currently there is no simple way to access common Sensei JS code in plugins. To do that we could either install directly from the GitHub repo or better we could publish common JS code to an npm library and use that. We could alternatively copy over any needed code but this would lead to a lot of code duplication.

To avoid the above issues, I used the [block variation API](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-variations/) to reuse the core buttons block. 

I think that the main benefit of using it is that we reuse the core button block which ensures compatibility and gets us any future updates automatically. The main drawback is that the block needs to rely on a custom value for the url to work and if the user modifies that, it will behave like a normal button block.

### Changes proposed in this Pull Request

* Adds a buttons block variation which automatically adds a 'View Certificate' button with any required values predefined.
* Adds a button block variation which allows users to add the 'View Certificate' button in a normal buttons block.

### Alternatives considered
* Exposing Sensei JS code to the plugins. Rejected because it probably needs a lot of time to do it properly.
* Create a new block that would reuse the core buttons block. Rejected because it seems that the variations API is more fitting.

### Testing instructions

* Add the block variation in a course page.
* Create a certificate template to the course.
* Complete the course with a user.
* Observe that the button now appears and in the fronend and that it can be used to access the certificate.
