### PR TITLE
Decode any encoded HTML entities in the student's name.

### DIFF
--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -796,6 +796,8 @@ class WooThemes_Sensei_Certificates {
 				$student_name = $fname . ' ' . $lname;
 			}
 
+			$student_name = html_entity_decode($student_name, ENT_QUOTES);
+
 			// Get Course Data
 			$course_id       = get_post_meta( $certificate_id, 'course_id', true );
 			$course_title    = get_post_field('post_title', $course_id);


### PR DESCRIPTION
Requires the ENT_QUOTES option for the fix to work with encoded single quotes.

Fixes #265 

### Changes proposed in this Pull Request

* Decode HTML entities in student's name when displayed on certificate.

### Testing instructions

* View a certificate issued to a student with encoded HTML entities in their name (e.g. Brian O'Conner)

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

N/A

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

N/A

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

![Screen Shot 2021-05-20 at 10 24 54 am](https://user-images.githubusercontent.com/713141/118901072-bed63480-b955-11eb-8aaf-563b3e6a93e0.png)
