### PR TITLE
Fix preview font for multibyte texts

### DIFF
--- a/classes/class-woothemes-sensei-certificate-templates.php
+++ b/classes/class-woothemes-sensei-certificate-templates.php
@@ -623,7 +623,7 @@ class WooThemes_Sensei_Certificate_Templates {
 				$fonttype = $this->get_font_type( $value );
 				switch ( $fonttype ) {
 					case 'mb':
-						$fpdf->SetFont( 'DejaVu', '', $font['font_size'] );
+						$fpdf->SetFont( 'dejavusanscondensed', '', $font['font_size'] );
 						break;
 					case 'latin':
 						$fpdf->SetFont( $font['font_family'], $font['font_style'], $font['font_size'] );
@@ -716,7 +716,7 @@ class WooThemes_Sensei_Certificate_Templates {
 				$fonttype = $this->get_font_type( $value );
 				switch ( $fonttype ) {
 					case 'mb':
-						$fpdf->SetFont( 'DejaVu', '', $font['font_size'] );
+						$fpdf->SetFont( 'dejavusanscondensed', '', $font['font_size'] );
 						break;
 					case 'latin':
 						$fpdf->SetFont( $font['font_family'], $font['font_style'], $font['font_size'] );


### PR DESCRIPTION
Fixes #268

### Changes proposed in this Pull Request

* Update name of baked-in font used for multibyte text boxes in preview mode
  * Follow-up to #149 where the font name changed. It was already updated for PDF generation.

### Testing instructions

* Have a Message field in a certificate template, and add text with special characters as Message Text. `Árvíztűrő tükörfúrógép` is a popular one here.
* Click `Preview` and observe that there is no fatal error and the certificate preview is displayed.


<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="1438" alt="image" src="https://user-images.githubusercontent.com/176949/123986205-666b6b80-d9c6-11eb-8d95-44f29fab0c89.png">
