### PR TITLE
Add View Certificate button to course completed page automatically

### DIFF
--- a/assets/blocks/index.js
+++ b/assets/blocks/index.js
@@ -4,17 +4,16 @@
 import { __ } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
 
-const addBlockToTemplate = ( props ) => {
-	props.push( [
+const addBlockToTemplate = ( blocks ) => ( [
+	...blocks,
+	[
 		'core/button',
 		{
 			className: 'view-certificate',
 			text: __( 'View Certificate', 'sensei-certificates' ),
 		},
-	] );
-
-	return props;
-};
+	]
+] );
 
 // Add this block to the Course Completed Actions block.
 addFilter(

--- a/assets/blocks/index.js
+++ b/assets/blocks/index.js
@@ -14,6 +14,10 @@ registerBlockVariation( 'core/button', {
 	name: 'sensei-certificates/view-certificate-button',
 	title: __( 'View Certificate', 'sensei-certificates' ),
 	description: __( 'Allow a user to view the course certificate.', 'sensei-certificates' ),
+	keywords: [
+		__( 'Certificates', 'sensei-lms' ),
+	],
+	category: 'sensei-lms',
 	attributes,
 	isActive: ( blockAttributes, variationAttributes ) =>
 		blockAttributes.className.match( variationAttributes.className ),

--- a/assets/blocks/index.js
+++ b/assets/blocks/index.js
@@ -20,7 +20,7 @@ registerBlockVariation( 'core/button', {
 	category: 'sensei-lms',
 	attributes,
 	isActive: ( blockAttributes, variationAttributes ) =>
-		blockAttributes.className.match( variationAttributes.className ),
+		blockAttributes.className?.match( variationAttributes.className ),
 } );
 
 const addBlockToTemplate = ( blocks ) => ( [

--- a/assets/blocks/index.js
+++ b/assets/blocks/index.js
@@ -13,7 +13,7 @@ const attributes = {
 registerBlockVariation( 'core/button', {
 	name: 'sensei-certificates/view-certificate-button',
 	title: __( 'View Certificate', 'sensei-certificates' ),
-	description: __( 'Allow a user to view the course certificate.', 'sensei-certificates' ),
+	description: __( 'Enable a learner to view their course certificate.', 'sensei-certificates' ),
 	keywords: [
 		__( 'Certificates', 'sensei-lms' ),
 	],

--- a/assets/blocks/index.js
+++ b/assets/blocks/index.js
@@ -3,16 +3,25 @@
  */
 import { __ } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
+import { registerBlockVariation } from '@wordpress/blocks';
+
+const attributes = {
+	className: 'view-certificate',
+	text: __( 'View Certificate', 'sensei-certificates' ),
+};
+
+registerBlockVariation( 'core/button', {
+	name: 'sensei-certificates/view-certificate-button',
+	title: __( 'View Certificate', 'sensei-certificates' ),
+	description: __( 'Allow a user to view the course certificate.', 'sensei-certificates' ),
+	attributes,
+	isActive: ( blockAttributes, variationAttributes ) =>
+		blockAttributes.className.match( variationAttributes.className ),
+} );
 
 const addBlockToTemplate = ( blocks ) => ( [
 	...blocks,
-	[
-		'core/button',
-		{
-			className: 'view-certificate',
-			text: __( 'View Certificate', 'sensei-certificates' ),
-		},
-	]
+	[ 'core/button', attributes ]
 ] );
 
 // Add this block to the Course Completed Actions block.

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -1594,43 +1594,37 @@ class WooThemes_Sensei_Certificates {
 				 * when created through the block editor.
 				 */
 				if (
-					'core/buttons' === $block['blockName']
-					&& isset( $block['innerContent'] )
-					&& isset( $block['innerContent'][0] )
-					& false !== strpos( $block['innerContent'][0], 'id="course-completed-actions"' )
+					'core/buttons' !== $block['blockName']
+					|| ! isset( $block['innerContent'] )
+					|| ! isset( $block['innerContent'][0] )
+					|| false === strpos( $block['innerContent'][0], 'id="course-completed-actions"' )
 				) {
-					$has_view_certificate = false;
+					return $block;
+				}
 
-					// Check if action buttons contains the View Certificate button.
-					foreach ( $block['innerBlocks'] as $inner_block ) {
-						if (
-							isset( $inner_block['attrs'] )
-							&& isset( $inner_block['attrs']['className'] )
-							&& false !== strpos( $inner_block['attrs']['className'], $class_name )
-						) {
-							$has_view_certificate = true;
-							break;
-						}
-					}
-
-					// Skip if it already contains the button.
-					if ( $has_view_certificate ) {
+				// Check if action buttons contains the View Certificate button.
+				foreach ( $block['innerBlocks'] as $inner_block ) {
+					if (
+						isset( $inner_block['attrs'] )
+						&& isset( $inner_block['attrs']['className'] )
+						&& false !== strpos( $inner_block['attrs']['className'], $class_name )
+					) {
 						return $block;
 					}
-
-					// Add space for the button in the second to last item in the innerContent.
-					array_splice( $block['innerContent'], count( $block['innerContent'] ) - 1, 0, [ null ] );
-
-					// Add button to the innerBlocks.
-					array_push(
-						$block['innerBlocks'],
-						[
-							'blockName'    => 'core/button',
-							'innerContent' => [ '<div class="wp-block-button ' . $class_name . '"><a class="wp-block-button__link">' . __( 'View Certificate', 'sensei-certificates' ) . '</a></div>' ],
-							'attrs'        => [ 'className' => $class_name ],
-						]
-					);
 				}
+
+				// Add space for the button in the second to last item in the innerContent.
+				array_splice( $block['innerContent'], count( $block['innerContent'] ) - 1, 0, [ null ] );
+
+				// Add button to the innerBlocks.
+				array_push(
+					$block['innerBlocks'],
+					[
+						'blockName'    => 'core/button',
+						'innerContent' => [ '<div class="wp-block-button ' . $class_name . '"><a class="wp-block-button__link">' . __( 'View Certificate', 'sensei-certificates' ) . '</a></div>' ],
+						'attrs'        => [ 'className' => $class_name ],
+					]
+				);
 
 				return $block;
 			},

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -185,6 +185,7 @@ class WooThemes_Sensei_Certificates {
 		// Blocks
 		add_action( 'enqueue_block_editor_assets', [ $instance, 'enqueue_block_editor_assets' ] );
 		add_filter( 'render_block', [ $instance, 'update_view_certificate_button_url' ], 10, 2 );
+		add_filter( 'sensei_course_completed_page_template', [ $instance, 'add_certificate_button_to_course_completed_template' ] );
 	}
 
 	/**
@@ -1514,6 +1515,34 @@ class WooThemes_Sensei_Certificates {
 
 		return Sensei_Blocks::update_button_block_url( $block_content, $block, $class_name,
 			WooThemes_Sensei_Certificates::instance()->get_certificate_url( $course_id, get_current_user_id() ) );
+	}
+
+	/**
+	 * Add certificate button to course completed template.
+	 * This template is used when creating the page through Sensei Setup Wizard.
+	 *
+	 * @param {array} $blocks Blocks array.
+	 *
+	 * @return {array} Blocks array.
+	 */
+	public function add_certificate_button_to_course_completed_template( $blocks ) {
+		$blocks = array_map(
+			function( $block ) {
+				if (
+					'core/buttons' === $block['blockName']
+					&& isset( $block['attrs'] )
+					&& 'course-completed-actions' === $block['attrs']['anchor']
+				) {
+					$button_content        = '<!-- wp:button {"className":"view-certificate"} --><div class="wp-block-button view-certificate"><a class="wp-block-button__link">' . __( 'View Certificate', 'sensei-certificates' ) . '</a></div><!-- /wp:button -->';
+					$block['innerContent'] = str_replace( '<!-- /wp:button --></div>', "<!-- /wp:button -->{$button_content}</div>", $block['innerContent'] );
+				}
+
+				return $block;
+			},
+			$blocks
+		);
+
+		return $blocks;
 	}
 
 	/**

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -1521,6 +1521,10 @@ class WooThemes_Sensei_Certificates {
 	 * Add certificate button to course completed template.
 	 * This template is used when creating the page through Sensei Setup Wizard.
 	 *
+	 * @since 2.2.1
+	 *
+	 * @access private
+	 *
 	 * @param {array} $blocks Blocks array.
 	 *
 	 * @return {array} Blocks array.
@@ -1533,8 +1537,16 @@ class WooThemes_Sensei_Certificates {
 					&& isset( $block['attrs'] )
 					&& 'course-completed-actions' === $block['attrs']['anchor']
 				) {
-					$button_content        = '<!-- wp:button {"className":"view-certificate"} --><div class="wp-block-button view-certificate"><a class="wp-block-button__link">' . __( 'View Certificate', 'sensei-certificates' ) . '</a></div><!-- /wp:button -->';
-					$block['innerContent'] = str_replace( '<!-- /wp:button --></div>', "<!-- /wp:button -->{$button_content}</div>", $block['innerContent'] );
+					array_splice( $block['innerContent'], count( $block['innerContent'] ) - 1, 0, [ null ] );
+
+					array_push(
+						$block['innerBlocks'],
+						[
+							'blockName'    => 'core/button',
+							'innerContent' => [ '<div class="wp-block-button view-certificate"><a class="wp-block-button__link">' . __( 'View Certificate', 'sensei-certificates' ) . '</a></div>' ],
+							'attrs'        => [ 'className' => 'view-certificate' ],
+						]
+					);
 				}
 
 				return $block;

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -1537,7 +1537,7 @@ class WooThemes_Sensei_Certificates {
 	/**
 	 * Add certificate button to Course Completed page, when already created.
 	 * It's useful for cases where the user already created the Course Completed
-	 * page, and then they activate the this plugin.
+	 * page, and then they activate this plugin.
 	 *
 	 * @since 2.2.1
 	 *
@@ -1618,8 +1618,10 @@ class WooThemes_Sensei_Certificates {
 						return $block;
 					}
 
-					// Add the button block.
+					// Add space for the button in the second to last item in the innerContent.
 					array_splice( $block['innerContent'], count( $block['innerContent'] ) - 1, 0, [ null ] );
+
+					// Add button to the innerBlocks.
 					array_push(
 						$block['innerBlocks'],
 						[

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -1550,7 +1550,7 @@ class WooThemes_Sensei_Certificates {
 			return;
 		}
 
-		update_option( $option_name, true );
+		update_option( $option_name, 1 );
 
 		$page_id = isset( Sensei()->settings->settings['course_completed_page'] ) ? intval( Sensei()->settings->settings['course_completed_page'] ) : 0;
 		if ( ! $page_id ) {


### PR DESCRIPTION
Fixes #276
Fixes #278

### Changes proposed in this Pull Request

* It includes a filter that adds the View Certificate button to the page when created through Setup Wizard.
* It adds a block variation, so it improves the discoverability of the block.
* If the page was already created without the button, it adds the button to the page. This is tried once.
* It introduces a new option and this option is not removed on the plugin is uninstalled. For now, I just created an issue to implement the uninstall feature: https://github.com/woocommerce/sensei-certificates/issues/281

### Testing instructions

* If https://github.com/Automattic/sensei/pull/4293 is not merged yet, go to this branch in the Sensei core: `add/more-courses-variation`.
* Remove the Course Completed page if you already have it.
* Submit the first step of the Setup Wizard.
* Make sure the page was created with the View Certificate button. Also, make sure it works well in the frontend and in the page editor.
* Go to the page editor, remove the button, and make sure you can add it again as an inner block. Also, make sure it's identified as the correct variation in the sidebar (with the title "View Certificate"). Make sure it works properly in the frontend and in the editor.
* Remove the View Certificate button.
* Refresh the editor, and make sure it's removed.
* Remove the WP option `sensei_certificates_view_certificate_button_added` from the database. Or clear it in `/wp-admin/options.php`.
* Refresh any admin page, and make sure the button was automatically added to the Course Completed page.