### PR TITLE
The bug for php 8 has been fixed

### DIFF
--- a/lib/tfpdf/tFPDF/PDF.php
+++ b/lib/tfpdf/tFPDF/PDF.php
@@ -1148,6 +1148,9 @@ class PDF
         } else {
             $str_family = strtolower($str_family);
         }
+        if (is_array($str_style)) { 
+            $str_style = ''; 
+        }
         $str_style = strtoupper($str_style);
         if (strpos($str_style, 'U') !== false) {
             $this->bol_underline = true;


### PR DESCRIPTION
Fatal error: Uncaught TypeError: strtoupper(): Argument #1 ($string) must be of type string, array given in /**/wp-content/plugins/sensei-certificates/lib/tfpdf/tFPDF/PDF.php:1151

Fixes #

### Changes proposed in this Pull Request

*

### Testing instructions

*

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

*

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

*

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video
