### PR TITLE
Redirect to login when viewing a certificate as a guest

### DIFF
--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -754,9 +754,15 @@ class WooThemes_Sensei_Certificates {
 			$pdf->generate_pdf();
 			exit;
 
-		} else {
+		} elseif ( is_user_logged_in() ) {
 
 			wp_die( esc_html__( 'You are not allowed to view this Certificate.', 'sensei-certificates' ), esc_html__( 'Certificate Error', 'sensei-certificates' ) );
+
+		} else {
+
+			// Redirect to the login page.
+			wp_safe_redirect( wp_login_url( get_permalink() ) );
+			exit;
 
 		} // End If Statement
 


### PR DESCRIPTION
Fixes #184

### Changes proposed in this Pull Request

* Improve the user experience by redirecting guest users to the login page when trying to view a certificate that is not public.

### Testing instructions

* Complete a course that has a certificate.
* Copy the certificate link.
* Logout.
* Access the certificate link.
* Make sure you are redirected to the login page.
* Login.
* Make sure you are redirected to the certificate link after logging in.
