### PR TITLE
Bump the PHP version to 7.0 for phpcs and the dependency checker

### DIFF
--- a/classes/class-woothemes-sensei-certificates-dependency-checker.php
+++ b/classes/class-woothemes-sensei-certificates-dependency-checker.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 2.0.0
  */
 class Woothemes_Sensei_Certificates_Dependency_Checker {
-	const MINIMUM_PHP_VERSION    = '5.6';
+	const MINIMUM_PHP_VERSION    = '7.0';
 	const MINIMUM_SENSEI_VERSION = '1.11.0';
 
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -13,7 +13,7 @@
 	<exclude-pattern>tests/</exclude-pattern>
 	<!-- Configs -->
 	<config name="minimum_supported_wp_version" value="4.9" />
-	<config name="testVersion" value="5.6-"/>
+	<config name="testVersion" value="7.0-"/>
 	<!-- Rules -->
 	<rule ref="PHPCompatibilityWP"/>
 	<rule ref="WordPress-Docs" />


### PR DESCRIPTION
### Changes proposed in this Pull Request

The [readme.txt](https://github.com/woocommerce/sensei-certificates/blob/master/readme.txt#L6) requires PHP 7.0. This PR just bumps the PHP version for phpcs and the dependency checker.

### Testing instructions

* Use a PHP 7.0 syntax somewhere in the code.
* Make sure phpcs is happy.
* Make sure the plugin is loading.