### PR TITLE
Fix report links on the certificates listing

### DIFF
--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -587,11 +587,12 @@ class WooThemes_Sensei_Certificates {
 				echo '<a href="' . esc_url(
 					add_query_arg(
 						array(
-							'page'      => 'sensei_analysis',
+							'page'      => 'sensei_reports',
+							'post_type' => 'course',
 							'user_id'   => intval( $user_id ),
 							'course_id' => intval( $course_id ),
 						),
-						admin_url( 'admin.php' )
+						admin_url( 'edit.php' )
 					)
 				) . '">' . esc_html( "{$user->display_name} ({$user->user_login})" ) . '</a>';
 				break;
@@ -599,10 +600,11 @@ class WooThemes_Sensei_Certificates {
 				echo '<a href="' . esc_url(
 					add_query_arg(
 						array(
-							'page'      => 'sensei_analysis',
+							'page'      => 'sensei_reports',
+							'post_type' => 'course',
 							'course_id' => intval( $course_id ),
 						),
-						admin_url( 'admin.php' )
+						admin_url( 'edit.php' )
 					)
 				) . '">' . esc_html( $course->post_title ) . '</a>';
 				break;

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -588,11 +588,10 @@ class WooThemes_Sensei_Certificates {
 					add_query_arg(
 						array(
 							'page'      => 'sensei_reports',
-							'post_type' => 'course',
 							'user_id'   => intval( $user_id ),
 							'course_id' => intval( $course_id ),
 						),
-						admin_url( 'edit.php' )
+						admin_url( 'admin.php' )
 					)
 				) . '">' . esc_html( "{$user->display_name} ({$user->user_login})" ) . '</a>';
 				break;
@@ -601,10 +600,9 @@ class WooThemes_Sensei_Certificates {
 					add_query_arg(
 						array(
 							'page'      => 'sensei_reports',
-							'post_type' => 'course',
 							'course_id' => intval( $course_id ),
 						),
-						admin_url( 'edit.php' )
+						admin_url( 'admin.php' )
 					)
 				) . '">' . esc_html( $course->post_title ) . '</a>';
 				break;


### PR DESCRIPTION
### Changes proposed in this Pull Request

The learner and course report links on the certificates listing table were pointing to the old reports page URL. This fixes that.

### Testing instructions

* Have a user with a certificate.
* Go to Certificates.
* Make sure the links in the "Learner" and "Course" columns work as expected.

### Screenshots

<img width="763" alt="Markup 2022-05-25 at 20 08 19" src="https://user-images.githubusercontent.com/1612178/170320887-4163bc12-f3e0-48e7-8efd-5c671c681c70.png">

