### PR TITLE
Remove argument warning

### DIFF
--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -841,7 +841,7 @@ class WooThemes_Sensei_Certificates {
 
 			// Define the data we're going to load: Key => Default value
 			$load_data = array(
-				'certificate_font_style'      => array(),
+				'certificate_font_style'      => '',
 				'certificate_font_color'      => array(),
 				'certificate_font_size'       => array(),
 				'certificate_font_family'     => array(),


### PR DESCRIPTION
This fixes the following warning which was displayed when a user tried to access his certificate:
```
( ! ) Warning: strtoupper() expects parameter 1 to be string, array given in /Users/gikaragia/Desktop/local/senseipro/app/public/wp-content/plugins/sensei-certificates/lib/tfpdf/tFPDF/PDF.php on line 1151
```

There was a path in which method `tFPDF\PDF::SetFont` would be called with an empty array.

### Steps to reproduce

* Create a new certificate template.
* Do not set any font style (Bold, Italic etc.)
* Set the certificate to a course and complete the course with the user.
* Try accessing the certificate

### What I expected
No warnings to be displayed

### What happened instead
Warnings were displayed