### PR TITLE
Fixes the `require_once` path for `class-vip-tfpdf.php`

### DIFF
--- a/classes/class-woothemes-sensei-certificates-tfpdf.php
+++ b/classes/class-woothemes-sensei-certificates-tfpdf.php
@@ -23,7 +23,7 @@ class Woothemes_Sensei_Certificates_TFPDF {
 		require_once dirname( __DIR__ ) . '/lib/tfpdf/tFPDF/TTFontFile.php';
 
 		if ( defined( 'WPCOM_IS_VIP_ENV' ) && true === WPCOM_IS_VIP_ENV ) {
-			require_once dirname( __FILE__ ) . 'class-vip-tfpdf.php';
+			require_once dirname( __FILE__ ) . '/class-vip-tfpdf.php';
 
 			return new VIP_tFPDF( $orientation, $units, $size );
 		}


### PR DESCRIPTION
Reported at https://wordpress.org/support/topic/bug-in-version-2-3-0/.

### Changes proposed in this Pull Request

Adds a slash to the `require_once` that tries to load the path: `class-vip-tfpdf.php`

https://github.com/woocommerce/sensei-certificates/blob/bb17712bb25ce2766ca82320f7cf5b4e50ff4c82/classes/class-woothemes-sensei-certificates-tfpdf.php#L26

Without this slash, the path is `wp-content/plugins/sense-certificates/classesclass-vip-tfpdf.php`, per the error shown:

![Image 2023-05-30 at 9 42 59 am](https://github.com/woocommerce/sensei-certificates/assets/2500940/897cf565-4973-4230-9b57-154b214c0747)

### Testing instructions

* Check out branch
* View certificates to ensure error is resolved, or
* Load up the file in your IDE and have it double-check the loaded path
