### PR TITLE
Fix deprecation notice for creation of dynamic property

### DIFF
--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -54,6 +54,11 @@ class WooThemes_Sensei_Certificates {
 	private static $_instance = null;
 
 	/**
+	 * @var Sensei_Assets|null
+	 */
+	public $assets;
+
+	/**
 	 * @var string url link to plugin files
 	 */
 	public $plugin_url;


### PR DESCRIPTION
### Changes proposed in this Pull Request

Fix deprecation notice for creation of dynamic property:

```
[23-Aug-2023 11:38:38 UTC] PHP Deprecated:  Creation of dynamic property WooThemes_Sensei_Certificates::$assets is deprecated in /Users/m1r0/Projects/sensei-certificates/classes/class-woothemes-sensei-certificates.php on line 110
```

### Testing instructions

* Activate the Sensei extension on a site with PHP 8.2 and debug logging enabled.
* View the log file, no deprecation notice is expected.
