### PR TITLE
Fix missing "View Certificate" link in `sensei_user_courses` shortcode

### DIFF
--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -1084,43 +1084,28 @@ class WooThemes_Sensei_Certificates {
 		$view_link_profile  = Sensei()->settings->settings['certificates_view_profile'];
 		$is_viewable        = false;
 
-		if (
-			(
-				(
-					is_page( $my_account_page_id )
-					|| is_singular( 'course' )
-					|| isset( $wp_query->query_vars['course_results'] )
-				)
-				&& $view_link_courses
-			) || (
-				isset( $wp_query->query_vars['learner_profile'] )
-				&& $view_link_profile
-			)
-		) {
+		if ( ( 'page' == get_post_type( $my_account_page_id )
+			|| is_singular( 'course' )
+			|| isset( $wp_query->query_vars['course_results'] ) ) && $view_link_courses
+			|| isset( $wp_query->query_vars['learner_profile'] ) && $view_link_profile ) {
 			$is_viewable = true;
-
-		} // End If Statement
-
-		if ( ! $is_viewable ) {
-
-			return $message;
-
 		}
 
-		$certificate_id     = $this->get_certificate_id( $course_id, $user_id );
+		if ( ! $is_viewable ) {
+			return $message;
+		}
+
+		$certificate_id = $this->get_certificate_id( $course_id, $user_id );
+
 		if ( ! $this->can_view_certificate( $certificate_id ) ) {
 			return $message;
 		}
 
 		if ( is_singular( 'course' ) ) {
-
 			$certificate_url = $this->get_certificate_url( $post->ID, $user_id );
-
 		} else {
-
 			$certificate_url = $this->get_certificate_url( $course_id, $user_id );
-
-		} // End If Statement
+		}
 
 		if ( '' != $certificate_url ) {
 

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -1079,15 +1079,15 @@ class WooThemes_Sensei_Certificates {
 			return $message;
 		}
 
-		$my_account_page_id = intval( Sensei()->settings->settings['my_course_page'] );
+		$my_courses_page_id = intval( Sensei()->settings->settings['my_course_page'] );
 		$view_link_courses  = Sensei()->settings->settings['certificates_view_courses'];
 		$view_link_profile  = Sensei()->settings->settings['certificates_view_profile'];
 		$is_viewable        = false;
 
-		if ( ( 'page' == get_post_type( $my_account_page_id )
-			|| is_singular( 'course' )
-			|| isset( $wp_query->query_vars['course_results'] ) ) && $view_link_courses
-			|| isset( $wp_query->query_vars['learner_profile'] ) && $view_link_profile ) {
+		if ( ( 'page' == get_post_type( $my_courses_page_id ) // My Courses page
+			|| is_singular( 'course' ) // Single course page
+			|| isset( $wp_query->query_vars['course_results'] ) ) && $view_link_courses // Course results page
+			|| isset( $wp_query->query_vars['learner_profile'] ) && $view_link_profile ) { // Learner profile page
 			$is_viewable = true;
 		}
 
@@ -1111,7 +1111,7 @@ class WooThemes_Sensei_Certificates {
 
 			$classes = '';
 
-			if ( 'page' == get_post_type( $my_account_page_id ) || isset( $wp_query->query_vars['learner_profile'] ) ) {
+			if ( 'page' == get_post_type( $my_courses_page_id ) || isset( $wp_query->query_vars['learner_profile'] ) ) {
 
 				$classes = 'button ';
 


### PR DESCRIPTION
Fixes #347.

### Changes proposed in this Pull Request
Reverts [changes to the `if` condition](https://github.com/woocommerce/sensei-certificates/pull/341/files#diff-79049456e2b059cbdcd7080ec2f30f2b3a347b4c41746fd452a68d7be711ac26R1082) made in #341. In particular, the `is_page( $my_account_page_id )` is not equivalent to `'page' == get_post_type( $my_account_page_id )` on the legacy My Courses page, as `is_page` returns `false` for archive pages.

### Testing instructions
1. Attach a certificate to a course.
2. Complete the course as a student.
3. Add the `[sensei_user_courses]` shortcode to a page.
4. View that page as the student who completed the course.
5. Ensure the _View Certificate_ link is visible for that course and that it works.
6. In WP Admin, navigate to _Sensei LMS > Settings > Student Profiles_ and ensure _Public student profiles_ is checked.
7. In WP Admin, navigate to _Sensei LMS > Settings > Certificate Settings_ and ensure _Public Certificate_ is checked.
8. Ensure that there is a user who has completed at least one course that has a certificate.
9. As that user, navigate to their Learner profile (`<site-url>/learner/<login>`) and check `Allow my Certificates to be publicly viewed`. Save the setting.
10. Navigate to the _Completed Courses_ tab. Ensure the "View Certificate" button is visible.
11. Open the user's Learner profile in an incognito/private window.
12. Navigate to the _Completed Courses_ tab. Ensure the "View Certificate" button is visible.

### Screenshot / Video
![Screenshot 2023-09-13 at 10 51 56 AM](https://github.com/woocommerce/sensei-certificates/assets/1190420/999bb910-b758-4eac-92bb-dc8e6b63d929)