### PR TITLE
Allow Certificates to be removed from a Course

### DIFF
--- a/classes/class-woothemes-sensei-certificate-templates.php
+++ b/classes/class-woothemes-sensei-certificate-templates.php
@@ -899,7 +899,7 @@ class WooThemes_Sensei_Certificate_Templates {
 		} elseif ( $new_meta_value && $new_meta_value != $meta_value ) {
 			// If the new meta value does not match the old value, update it.
 			update_post_meta( $post_id, $meta_key, $new_meta_value );
-		} elseif ( '' == $new_meta_value && $meta_value ) {
+		} elseif ( 0 == $new_meta_value && $meta_value ) {
 			// If there is no new meta value but an old value exists, delete it.
 			delete_post_meta( $post_id, $meta_key, $meta_value );
 		}

--- a/classes/class-woothemes-sensei-certificate-templates.php
+++ b/classes/class-woothemes-sensei-certificate-templates.php
@@ -890,7 +890,7 @@ class WooThemes_Sensei_Certificate_Templates {
 
 		// Get the meta key.
 		$meta_key       = '_' . $post_key;
-		$new_meta_value = isset( $_POST[ $post_key ] ) ? intval( $_POST[ $post_key ] ) : '';
+		$new_meta_value = isset( $_POST[ $post_key ] ) && !empty($_POST[ $post_key ]) ? intval( $_POST[ $post_key ] ) : '';
 		// Get the meta value of the custom field key.
 		$meta_value = get_post_meta( $post_id, $meta_key, true );
 		// If a new meta value was added and there was no previous value, add it.
@@ -899,7 +899,7 @@ class WooThemes_Sensei_Certificate_Templates {
 		} elseif ( $new_meta_value && $new_meta_value != $meta_value ) {
 			// If the new meta value does not match the old value, update it.
 			update_post_meta( $post_id, $meta_key, $new_meta_value );
-		} elseif ( 0 == $new_meta_value && $meta_value ) {
+		} elseif ( '' == $new_meta_value && $meta_value ) {
 			// If there is no new meta value but an old value exists, delete it.
 			delete_post_meta( $post_id, $meta_key, $meta_value );
 		}


### PR DESCRIPTION
Fixes #334 

If a certificate has been set for a course, it cannot currently be removed in PHP 8+.

### Changes proposed in this Pull Request

This fix changes the save_post_meta function so if a certificate is removed for a course, the 'delete_post_meta' function gets called as originally intended.

### Testing instructions

* Create a course, add a certificate to the course and publish it.
* Update the course and for the Certificate, choose 'None'
* Reload the page
* The Certificate should be removed from the course

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

![sample](https://github.com/woocommerce/sensei-certificates/assets/5557433/becacb13-7ed2-4d86-bea0-cce74cffdbe2)

