### PR TITLE
Fix certificates not rendering on PHP 8.2

### DIFF
--- a/classes/class-woothemes-sensei-certificate-templates.php
+++ b/classes/class-woothemes-sensei-certificate-templates.php
@@ -55,6 +55,83 @@ class WooThemes_Sensei_Certificate_Templates {
 	public $token;
 
 	/**
+	 * Template post ID.
+	 *
+	 * @var int
+	 */
+	public $id;
+
+	/**
+	 * Template post meta fields.
+	 *
+	 * @var array|false|string
+	 */
+	public $certificate_template_custom_fields;
+
+	/**
+	 * Template image ids.
+	 *
+	 * @var array
+	 */
+	public $image_ids;
+
+	/**
+	 * Template main image id.
+	 *
+	 * @var int
+	 */
+	public $image_id;
+
+	/**
+	 * Template additional image ids.
+	 *
+	 * @var array
+	 */
+	public $additional_image_ids;
+
+	/**
+	 * Font color.
+	 *
+	 * @var
+	 */
+	public $certificate_font_color;
+
+	/**
+	 * Font size.
+	 *
+	 * @var array
+	 */
+	public $certificate_font_size;
+
+	/**
+	 * Font style.
+	 *
+	 * @var array
+	 */
+	public $certificate_font_style;
+
+	/**
+	 * Font family.
+	 *
+	 * @var array
+	 */
+	public $certificate_font_family;
+
+	/**
+	 * Heading position.
+	 *
+	 * @var array
+	 */
+	public $certificate_heading_pos;
+
+	/**
+	 * Template post meta fields
+	 *
+	 * @var
+	 */
+	public $certificate_template_fields;
+
+	/**
 	 * __construct function.
 	 *
 	 * @access public

--- a/classes/class-woothemes-sensei-certificate-templates.php
+++ b/classes/class-woothemes-sensei-certificate-templates.php
@@ -125,7 +125,7 @@ class WooThemes_Sensei_Certificate_Templates {
 	public $certificate_heading_pos;
 
 	/**
-	 * Template post meta fields
+	 * Template fields.
 	 *
 	 * @var
 	 */

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -73,6 +73,8 @@ class WooThemes_Sensei_Certificates {
 	public $_inline_js;
 
 	/**
+	 * Template image ids.
+	 *
 	 * @var array
 	 */
 	public $image_ids;
@@ -85,26 +87,36 @@ class WooThemes_Sensei_Certificates {
 	public $image_id;
 
 	/**
+	 * Font style.
+	 *
 	 * @var array
 	 */
 	public $certificate_font_style;
 
 	/**
+	 * Font color.
+	 *
 	 * @var array
 	 */
 	public $certificate_font_color;
 
 	/**
+	 * Font size.
+	 *
 	 * @var array
 	 */
 	public $certificate_font_size;
 
 	/**
+	 * Font family.
+	 *
 	 * @var array
 	 */
 	public $certificate_font_family;
 
 	/**
+	 * Template fields.
+	 *
 	 * @var array
 	 */
 	public $certificate_template_fields;

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -42,7 +42,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 
 class WooThemes_Sensei_Certificates {
-
 	/**
 	 * The single instance of WooThemes_Sensei_Certificates.
 	 *
@@ -72,6 +71,43 @@ class WooThemes_Sensei_Certificates {
 	 * @var string inline js code
 	 */
 	public $_inline_js;
+
+	/**
+	 * @var array
+	 */
+	public $image_ids;
+
+	/**
+	 * The main template image id.
+	 *
+	 * @var int|null
+	 */
+	public $image_id;
+
+	/**
+	 * @var array
+	 */
+	public $certificate_font_style;
+
+	/**
+	 * @var array
+	 */
+	public $certificate_font_color;
+
+	/**
+	 * @var array
+	 */
+	public $certificate_font_size;
+
+	/**
+	 * @var array
+	 */
+	public $certificate_font_family;
+
+	/**
+	 * @var array
+	 */
+	public $certificate_template_fields;
 
 	/**
 	 * __construct function.
@@ -607,6 +643,10 @@ class WooThemes_Sensei_Certificates {
 				) . '">' . esc_html( "{$user->display_name} ({$user->user_login})" ) . '</a>';
 				break;
 			case 'course':
+				if ( ! $course ) {
+					break;
+				}
+
 				echo '<a href="' . esc_url(
 					add_query_arg(
 						array(
@@ -621,6 +661,10 @@ class WooThemes_Sensei_Certificates {
 				echo wp_kses_post( $course_end_date );
 				break;
 			case 'actions':
+				if ( ! $course ) {
+					break;
+				}
+
 				$template_id = get_post_meta( $course_id, '_course_certificate_template', true );
 				if ( $template_id ) {
 					echo '<a href="' . esc_url( get_permalink( $post_ID ) ) . '" target="_blank">' . esc_html__( 'View Certificate', 'sensei-certificates' ) . '</a>';

--- a/classes/class-woothemes-sensei-pdf-certificate.php
+++ b/classes/class-woothemes-sensei-pdf-certificate.php
@@ -36,7 +36,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.0
  */
 class WooThemes_Sensei_PDF_Certificate {
-
 	/**
 	 * @var int preview post id
 	 */
@@ -52,6 +51,19 @@ class WooThemes_Sensei_PDF_Certificate {
 	 */
 	public $certificate_pdf_data;
 
+	/**
+	 * The certificate user data.
+	 *
+	 * @var array
+	 */
+	public $certificate_pdf_data_userdata;
+
+	/**
+	 * The background image path.
+	 *
+	 * @var string|null
+	 */
+	public $bg_image_src;
 
 	/**
 	 * Construct certificate with $hash

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "automattic/sensei-certificates",
   "description": "Sensei LMS Certificates",
   "require-dev": {
-    "php": "^7",
+    "php": "^7 || ^8",
     "dealerdirect/phpcodesniffer-composer-installer": "0.7.1",
     "phpcompatibility/phpcompatibility-wp": "2.1.1",
     "squizlabs/php_codesniffer": "3.5.8",
@@ -33,5 +33,10 @@
       ".*",
       "*.test.js"
     ]
+  },
+  "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,27 +4,27 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "93a2e5f280a1cf89183ee6018100541b",
+    "content-hash": "a52003dc60266d74e41c619548a6538b",
     "packages": [],
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.7.0",
+            "version": "v0.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "e8d808670b8f882188368faaf1144448c169c0b7"
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/e8d808670b8f882188368faaf1144448c169c0b7",
-                "reference": "e8d808670b8f882188368faaf1144448c169c0b7",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/fe390591e0241955f22eb9ba327d137e501c771c",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.0 || ^2.0",
                 "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2 || ^3 || 4.0.x-dev"
+                "squizlabs/php_codesniffer": "^2.0 || ^3.0 || ^4.0"
             },
             "require-dev": {
                 "composer/composer": "*",
@@ -75,7 +75,7 @@
                 "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
                 "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
             },
-            "time": "2020-06-25T14:57:39+00:00"
+            "time": "2020-12-07T18:04:37+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -141,28 +141,28 @@
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
-            "version": "1.3.1",
+            "version": "1.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
-                "reference": "ddabec839cc003651f2ce695c938686d1086cf43"
+                "reference": "293975b465e0e709b571cbf0c957c6c0a7b9a2ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/ddabec839cc003651f2ce695c938686d1086cf43",
-                "reference": "ddabec839cc003651f2ce695c938686d1086cf43",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/293975b465e0e709b571cbf0c957c6c0a7b9a2ac",
+                "reference": "293975b465e0e709b571cbf0c957c6c0a7b9a2ac",
                 "shasum": ""
             },
             "require": {
                 "phpcompatibility/php-compatibility": "^9.0"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
                 "paragonie/random_compat": "dev-master",
                 "paragonie/sodium_compat": "dev-master"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
@@ -187,26 +187,42 @@
                 "paragonie",
                 "phpcs",
                 "polyfill",
-                "standards"
+                "standards",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
+                "security": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/security/policy",
                 "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
             },
-            "time": "2021-02-15T10:24:51+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCompatibility",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-04-24T21:30:46+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",
-            "version": "2.1.0",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
-                "reference": "41bef18ba688af638b7310666db28e1ea9158b2f"
+                "reference": "b7dc0cd7a8f767ccac5e7637550ea1c50a67b09e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/41bef18ba688af638b7310666db28e1ea9158b2f",
-                "reference": "41bef18ba688af638b7310666db28e1ea9158b2f",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/b7dc0cd7a8f767ccac5e7637550ea1c50a67b09e",
+                "reference": "b7dc0cd7a8f767ccac5e7637550ea1c50a67b09e",
                 "shasum": ""
             },
             "require": {
@@ -214,10 +230,10 @@
                 "phpcompatibility/phpcompatibility-paragonie": "^1.0"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
@@ -247,20 +263,20 @@
                 "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
                 "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
             },
-            "time": "2019-08-28T14:22:28+00:00"
+            "time": "2021-02-15T12:58:46+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.5",
+            "version": "3.5.8",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6"
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
-                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/9d583721a7157ee997f235f327de038e7ea6dac4",
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4",
                 "shasum": ""
             },
             "require": {
@@ -303,7 +319,21 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2020-04-17T01:09:41+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2020-10-23T02:01:07+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -364,7 +394,7 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": {
-        "php": "^7"
+        "php": "^7 || ^8"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/lib/tfpdf/tFPDF/TTFontFile.php
+++ b/lib/tfpdf/tFPDF/TTFontFile.php
@@ -48,6 +48,8 @@ class TTFontFile
    private $charWidths;
    private $defaultWidth;
    private $maxStrLenRead;
+   private $maxUniChar;
+   private $glyphdata = array();
 
    public function __construct()
    {


### PR DESCRIPTION
Part of https://github.com/Automattic/sensei/issues/7635

### Changes proposed in this Pull Request

* Fix deprecation notices on PHP 8.2.
* Fix certificates not rendering on PHP 8.2 when notices are visible.
* Update composer to support PHP 8+.
* Skipped fixing the ["Function utf8_decode() is deprecated" notice](https://github.com/woocommerce/sensei-certificates/issues/355) because it needs deeper investigation and it doesn't block the rendering of the certificates.

### Testing instructions

* Use PHP 8.2.
* Create a certificate template, change some of the fields, and assign it to a course.
* Complete the course and view the certificate.
* Make sure there are no deprecation notices (except for the utf8_decode one mentioned above).
