### PR TITLE
Adjust the template check for the Certificate template preview

### DIFF
--- a/classes/class-woothemes-sensei-certificate-templates.php
+++ b/classes/class-woothemes-sensei-certificate-templates.php
@@ -162,7 +162,7 @@ class WooThemes_Sensei_Certificate_Templates {
 		}
 
 		// Preview Template
-		add_filter( 'single_template', array( $this, 'certificate_templates_locate_preview_template' ), 10, 3 );
+		add_filter( 'single_template', array( $this, 'certificate_templates_locate_preview_template' ), 10, 2 );
 
 	}
 

--- a/classes/class-woothemes-sensei-certificate-templates.php
+++ b/classes/class-woothemes-sensei-certificate-templates.php
@@ -162,7 +162,7 @@ class WooThemes_Sensei_Certificate_Templates {
 		}
 
 		// Preview Template
-		add_filter( 'single_template', array( $this, 'certificate_templates_locate_preview_template' ) );
+		add_filter( 'single_template', array( $this, 'certificate_templates_locate_preview_template' ), 10, 3 );
 
 	}
 
@@ -193,16 +193,15 @@ class WooThemes_Sensei_Certificate_Templates {
 	 * @param string $locate locate path
 	 * @return string the location path for the certificate template preview file
 	 */
-	function certificate_templates_locate_preview_template( $locate ) {
+	public function certificate_templates_locate_preview_template( $locate, $type, $templates ) {
 
 		$post_type = get_query_var( 'post_type' );
 
-		if ( 'certificate_template' == $post_type && strpos( $locate, 'single.php' ) ) {
+		if ( 'certificate_template' === $post_type && 'single' === $type ) {
 			$locate = $this->plugin_path() . '/templates/single-certificate_template.php';
 		}
 
 		return $locate;
-
 	}
 
 

--- a/classes/class-woothemes-sensei-certificate-templates.php
+++ b/classes/class-woothemes-sensei-certificate-templates.php
@@ -191,9 +191,11 @@ class WooThemes_Sensei_Certificate_Templates {
 	 * @access public
 	 * @since 1.0
 	 * @param string $locate locate path
+	 * @param string $type type of template
+	 *
 	 * @return string the location path for the certificate template preview file
 	 */
-	public function certificate_templates_locate_preview_template( $locate, $type, $templates ) {
+	public function certificate_templates_locate_preview_template( $locate, $type ) {
 
 		$post_type = get_query_var( 'post_type' );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Adjust the template check for the Certificate template preview to make sure that the preview template is used even if the current theme doesn't have any `single.php` template

### Description

By default, the plugin checks if `strpos( $locate, 'single.php' )` to confirm if the current page corresponds to a single certificate template page, but `$locate` is an empty string if the current theme doesn't have a `single.php` template, forcing the page to get rendered using the default page template. 

I suggest checking the `$type` parameter that is passed by the filter to check if it's a single template instead. 

### Testing instructions

* Activate a theme without a single.php template
* Create a certificate template
* Preview it
* Confirm that a PDF preview is rendered instead of using a default page template.

Mentions #361