### PR TITLE
Fix PHP warning about deprecated `utf8_decode` function on PHP 8.2+

### DIFF
--- a/classes/class-woothemes-sensei-certificate-templates.php
+++ b/classes/class-woothemes-sensei-certificate-templates.php
@@ -671,7 +671,7 @@ class WooThemes_Sensei_Certificate_Templates {
 
 			// Decode string based on font type
 			if ( 'latin' == $fonttype ) {
-				$value = utf8_decode( $value );
+				$value = Woothemes_Sensei_Certificates_Utils::convert_utf8_to_latin1( $value );
 			}
 
 			// and write out the value
@@ -772,7 +772,7 @@ class WooThemes_Sensei_Certificate_Templates {
 
 			// Decode string based on font type
 			if ( 'latin' == $fonttype ) {
-				$value = utf8_decode( $value );
+				$value = Woothemes_Sensei_Certificates_Utils::convert_utf8_to_latin1( $value );
 			}
 
 			// and write out the value

--- a/classes/class-woothemes-sensei-certificates-utils.php
+++ b/classes/class-woothemes-sensei-certificates-utils.php
@@ -66,4 +66,22 @@ class Woothemes_Sensei_Certificates_Utils {
 			$date_format
 		);
 	}
+
+	/**
+	 * Convert UTF-8 text to ISO-8859-1 with transliteration.
+	 *
+	 * Falls back to the original string if conversion fails.
+	 *
+	 * @param string $value Text to convert.
+	 * @return string
+	 */
+	public static function convert_utf8_to_latin1( $value ) {
+		if ( ! $value || ! is_string( $value ) ) {
+			return $value;
+		}
+
+		$converted = iconv( 'UTF-8', 'ISO-8859-1//TRANSLIT', $value );
+
+		return false === $converted ? $value : $converted;
+	}
 }

--- a/classes/class-woothemes-sensei-pdf-certificate.php
+++ b/classes/class-woothemes-sensei-pdf-certificate.php
@@ -253,7 +253,7 @@ class WooThemes_Sensei_PDF_Certificate {
 
 			// Decode string based on font type
 			if ( 'latin' == $fonttype ) {
-				$value = utf8_decode( $value );
+				$value = Woothemes_Sensei_Certificates_Utils::convert_utf8_to_latin1( $value );
 			}
 
 			// and write out the value
@@ -284,7 +284,7 @@ class WooThemes_Sensei_PDF_Certificate {
 			$fpdf->setXY( $x, $y );
 
 			// and write out the value
-			$fpdf->Image( esc_url( utf8_decode( $value ) ), $x, $y, $w, $h );
+			$fpdf->Image( esc_url( Woothemes_Sensei_Certificates_Utils::convert_utf8_to_latin1( $value ) ), $x, $y, $w, $h );
 
 		} // End If Statement
 
@@ -382,7 +382,7 @@ class WooThemes_Sensei_PDF_Certificate {
 
 			// Decode string based on font type
 			if ( 'latin' == $fonttype ) {
-				$value = utf8_decode( $value );
+				$value = Woothemes_Sensei_Certificates_Utils::convert_utf8_to_latin1( $value );
 			}
 
 			// and write out the value
@@ -456,7 +456,7 @@ class WooThemes_Sensei_PDF_Certificate {
 
 			// Decode string based on font type
 			if ( 'latin' == $fonttype ) {
-				$value = utf8_decode( $value );
+				$value = Woothemes_Sensei_Certificates_Utils::convert_utf8_to_latin1( $value );
 			}
 
 			// and write out the value


### PR DESCRIPTION
Resolves https://github.com/woocommerce/sensei-certificates/issues/364

### Changes proposed in this Pull Request

* This fixed a deprecation warning related to `utf8_decode` on PHP 8.2+.

### Testing instructions

* On Use PHP 8.2+, go to Certificates -> Certificate Templates -> Example Template and click the preview button. There should be no PHP warnings.
* Try adding `ë` to one of the text elements of the template and make sure the preview works as expected.
* Assign a certificate template to a course.
* Pass the course and view the certificate. There should be no warnings. 
