### PR TITLE
Add agent guidance files and skills

### DIFF
--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: pull-request
+description: >-
+  Open a GitHub pull request for the Sensei LMS Certificates plugin the way this
+  repo expects. Use this whenever the user wants to create, open, draft, or "put
+  up" a PR, or says things like "open a PR", "create a pull request", "make a PR
+  for this branch", or "PR this". It fills the repo's PULL_REQUEST_TEMPLATE.md
+  from the actual diff against trunk and stops for approval before pushing.
+  Prefer this over a bare `gh pr create` so the body matches the template
+  reviewers expect and the PR gets its required milestone.
+---
+
+# Open a Sensei LMS Certificates Pull Request
+
+Fill the repo's PR template from the diff and stop for approval before
+`gh pr create` — which pushes the branch.
+
+The repo is `woocommerce/sensei-certificates`. The base branch is `trunk`.
+
+## Steps
+
+### 1. Preconditions
+
+- Confirm the current branch is not `trunk`. If it is, stop — nothing to PR.
+- Confirm `gh` is authenticated: `gh auth status`. If not, ask the user to run
+  `! gh auth login` themselves.
+
+### 2. Understand the change from the diff
+
+Describe what the diff does, not how you got there.
+
+```bash
+git merge-base trunk HEAD          # fork point
+git log --oneline trunk..HEAD      # commits on this branch
+git diff --stat trunk...HEAD       # files touched
+git diff trunk...HEAD              # the actual change — read this
+```
+
+Read the diff. From it, decide the **title** — one line, imperative, concise, no
+conventional-commit prefix (no `feat:` / `fix:`).
+
+### 3. Fill the repo's PR template
+
+Read it and fill it in — don't invent your own headings:
+
+```bash
+cat .github/PULL_REQUEST_TEMPLATE.md
+```
+
+Per section:
+
+- **`Fixes #`** — fill as `Fixes #<n>` if the user gave an issue number, or one
+  appears in the branch name or commit messages. If there's no issue, remove the
+  line — a bare `Fixes #` is noise. Never guess a number.
+- **`### Changes proposed in this Pull Request`** — the reviewer-facing summary.
+  Lead with the problem/need and the user impact, then the approach at a high
+  level. Don't re-list modified files or narrate implementation — the diff shows
+  that.
+- **`### Testing instructions`** — manual steps a reviewer follows to verify
+  (click paths, expected on-screen results, edge cases). For certificate changes
+  this usually means: complete a course as a student, then check the certificate
+  renders, downloads as a PDF, and the "View Certificate" link/block appears.
+  Never list running automated suites — there are none.
+- **`### New/Updated Hooks`** — fill only if the diff adds or changes an action or
+  filter; describe each and its args, and plan to add the **Hooks** label. If the
+  diff touches no hooks, remove this whole section from the body.
+- **`### Deprecated Code`** — fill only if the diff deprecates something; name the
+  replacement and plan to add the **Deprecation** label. Otherwise remove the
+  section.
+- **`### Screenshot / Video`** — keep only when the change is visual (touches
+  `assets/`, blocks, or `templates/`). You can't capture the images yourself, so
+  at the approval gate remind the user to attach them. If the change isn't visual,
+  remove the section.
+
+### 4. Stop and confirm — this is the push gate
+
+Show the user the proposed **title** and the **filled template body** (call out any
+labels: Hooks / Deprecation). If you kept a Screenshot section, remind them to
+attach images. Wait for explicit approval. Do not run `gh pr create` until they
+say go — it pushes the branch and opens the PR, which is outward-facing and hard
+to walk back.
+
+### 5. Create the PR
+
+After approval:
+
+```bash
+gh pr create --base trunk --title "<title>" --body "<filled template body>"
+```
+
+`gh` pushes the current branch as part of this. Capture the PR number it prints,
+then apply any labels you flagged:
+
+```bash
+gh pr edit <PR_NUMBER> --add-label "Hooks"
+```
+
+### 6. Assign the milestone (required)
+
+Find the next shipping milestone (lowest-versioned open one) and assign it. Use
+`sort -V` — a plain sort mis-orders versions (e.g. `2.5.5` vs `2.10.0`):
+
+```bash
+next=$(gh api 'repos/woocommerce/sensei-certificates/milestones?state=open' --jq '.[].title' | sort -V | head -1)
+gh pr edit <PR_NUMBER> --milestone "$next"
+```
+
+If the user named a target release, use that milestone instead of the lowest.
+
+### 7. Wrap up
+
+Give the user the PR URL.

--- a/.claude/skills/ui-verification/SKILL.md
+++ b/.claude/skills/ui-verification/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: ui-verification
+description: >-
+  Verify a Sensei LMS Certificates UI or behavior change end-to-end against the
+  running WordPress site. Use after making a change that affects the certificate
+  template designer, the generated PDF, the "View Certificate" link/block, or any
+  admin/front-end surface, and whenever the user asks to "check it in the
+  browser", "verify the UI", "see if it works", or "smoke-test" a change. Scopes
+  what to check from `git diff`, drives the site via Chrome DevTools MCP, and
+  captures screenshots. This is agent-driven manual verification, not an automated
+  test suite — it does not run or write tests.
+---
+
+# Sensei LMS Certificates UI Verification
+
+Confirm a change behaves correctly from a user's perspective by driving the real
+site in a browser. Use this alongside — not instead of — writing automated tests
+for the change (see AGENTS.md "Testing").
+
+## Prerequisites
+
+- A running WordPress site with **both** Sensei LMS and this plugin active. This
+  repo has no wp-env/Docker of its own — use the local site this checkout lives
+  under. Confirm the site's base URL and an admin login with the user before
+  driving it.
+- At least one **course a student can complete**, so a certificate gets
+  generated. If none exists, create a course + a student enrollment first (or ask
+  the user to point you at an existing completed course).
+- Chrome DevTools MCP tools (`mcp__chrome-devtools__*`) available.
+- For changes under `assets/`, run `npm run build:assets` first — the browser
+  loads the built files in `assets/dist/`, not the source. Hard-reload after.
+
+## Certificate surface map
+
+Ranked by what a certificates change usually touches. Admin paths are stable;
+front-end URLs depend on the site's permalinks — discover them by navigating.
+
+| Area | Where | Verify when changing |
+|------|-------|----------------------|
+| Certificate Templates CPT | `/wp-admin/edit.php?post_type=certificate_template` | Template list, the design/write panels (background image, fonts, field placement) |
+| Certificates settings | `/wp-admin/admin.php?page=sensei-settings` → Certificates tab | Settings save/load, "View in Learner Profile" / public-sharing options |
+| Sensei Tools | `/wp-admin/admin.php?page=sensei-tools` | Bulk certificate generation / data cleanup actions |
+| Single course (front end) | the course page, as a student who completed it | "View Certificate" button/link appears and links correctly |
+| Certificate PDF | the "View Certificate" / download link | PDF renders, downloads, and the content (name, course, date) is correct |
+| Learner profile | the student's public profile page | "View Certificate" link shows when enabled |
+| Course List block / archive | `/courses/` or a page using the block | "View Certificate" link on completed courses |
+| View Certificate block | block editor + the front-end page embedding it | Editor insert/config and front-end render |
+
+## Workflow
+
+### 1. Scope from the diff
+
+```bash
+git diff trunk...HEAD --name-only
+```
+
+Map changed files to surfaces; skip surfaces the diff doesn't touch:
+
+- `admin/` or `classes/class-woothemes-sensei-certificate-templates.php` → template designer + write panels.
+- `classes/class-woothemes-sensei-pdf-certificate.php`, `class-woothemes-sensei-certificates-tfpdf.php`, `class-vip-tfpdf.php`, `lib/tfpdf/` → generate and open a certificate PDF; inspect the rendered output.
+- `assets/blocks/`, `classes/blocks/` → the View Certificate block, in both the editor and the front end.
+- `templates/` → front-end certificate output.
+- `classes/class-woothemes-sensei-certificates.php` → the broad one: settings tab, download flow, learner-profile link, course list columns. Check whichever the diff's methods drive.
+
+### 2. Confirm the site is reachable
+
+Navigate to the base URL and confirm it loads before driving flows. If assets
+changed, confirm `npm run build:assets` ran.
+
+### 3. Drive the relevant flows
+
+For each in-scope surface, navigate, perform the action a user would, and confirm
+the expected result. The core happy path for most changes:
+
+1. As a student, complete (or open an already-completed) course.
+2. Confirm the "View Certificate" link/button appears where expected.
+3. Follow it; confirm the certificate PDF renders and downloads.
+4. Confirm the certificate content is correct (student name, course title, date).
+
+For admin/template changes, exercise the template designer: edit a template's
+background/fonts/field placement, save, then re-generate a certificate and confirm
+the change shows.
+
+### 4. Capture evidence
+
+Screenshot each verified surface (`mcp__chrome-devtools__take_screenshot`).
+Capture both the before/after or the final state depending on what the change
+affects.
+
+### 5. Report
+
+Summarize what you verified, per surface: what you did, what you expected, what
+you saw, and attach the screenshots. Call out anything that didn't match — don't
+claim a flow works unless you actually drove it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,70 @@
+Sensei LMS Certificates is a WordPress plugin that awards students a downloadable PDF certificate when they complete a Sensei LMS course. It extends [Sensei LMS](https://github.com/Automattic/sensei) (the sibling `sensei` plugin) and does not function without it — see the dependency section below.
+
+## Read before writing code
+This repo has no conventions docs of its own; it follows Sensei LMS's, canonical in the `sensei` repo.
+- Writing or changing a **test**? Read Sensei LMS's [unit-test conventions](https://github.com/Automattic/sensei/blob/trunk/docs/conventions/unit-tests.md) first.
+- Writing a **class, hook, meta key, block, or stylesheet**? Read Sensei LMS's [naming conventions](https://github.com/Automattic/sensei/blob/trunk/docs/conventions/naming.md) first.
+
+Apply them to code you add. Do not rewrite surrounding code to match. Where they conflict with this repo's established patterns (legacy prefixes, existing `learner` identifiers), the local pattern wins — see Conventions.
+
+## Repository layout
+- `woothemes-sensei-certificates.php` — plugin entry point. Defines constants, runs the dependency checker, then boots `WooThemes_Sensei_Certificates`. Also the source of truth for `Requires PHP` and `Requires at least` (minimum WordPress).
+- `classes/` — main plugin PHP source. Key files:
+  - `class-woothemes-sensei-certificates.php` — main class (certificate generation, settings, download, hooks into Sensei).
+  - `class-woothemes-sensei-certificate-templates.php` — the `certificate` / `certificate_template` custom post types and the design system.
+  - `class-woothemes-sensei-pdf-certificate.php` + `class-woothemes-sensei-certificates-tfpdf.php` / `class-vip-tfpdf.php` — PDF rendering on top of the bundled tFPDF library.
+  - `class-woothemes-sensei-certificates-dependency-checker.php` — gates activation on PHP version and the Sensei LMS dependency.
+  - `blocks/`, `background-jobs/`, `tools/` — the "View Certificate" block, bulk certificate generation jobs, and Sensei LMS Tools integrations.
+- `admin/` — admin post-type UI and write panels for the certificate template designer.
+- `assets/` — JS/SCSS source and blocks; built artifacts land in `assets/dist/` (git-ignored, produced by the build).
+- `templates/` — front-end certificate templates (overridable by themes).
+- `lib/tfpdf/` — vendored tFPDF PDF library. Treat as read-only third-party code; excluded from linting.
+- `lang/` — translations and the `.pot` file.
+- `sensei-certificates-functions.php` — global template/helper functions.
+- `.github/` — PR and issue templates only; there are no CI workflows in this repo.
+
+## Sensei LMS dependency
+
+Sensei LMS Certificates is a **runtime** extension of Sensei LMS — there is no build-time coupling to the `sensei` source, but at runtime the `sensei` plugin must be installed and active, or this plugin deactivates itself.
+
+- The gate lives in `Woothemes_Sensei_Certificates_Dependency_Checker`: it requires the `Sensei_Main` class and the `sensei-version` option to be at least the `MINIMUM_SENSEI_VERSION` constant declared there (source of truth for the minimum Sensei LMS version).
+- Code here consumes Sensei LMS APIs directly: the `Sensei()` global, `Sensei_Assets`, `Sensei_Settings`, and course/lesson data. When you touch these, check the sibling `sensei` checkout (usually `../sensei`) for the current signatures rather than guessing.
+- **Do not vendor or duplicate Sensei LMS code here.** If a shared concern needs fixing, fix it in the `sensei` repo. Treat the `sensei` source as read-only from this repo.
+- To exercise this plugin locally you need both plugins active in the same WordPress install with a course a student can complete.
+
+## Development environment
+- Match your Node version to `.nvmrc` (`nvm use` reads it) before any `npm` command, so the committed `package-lock.json` isn't rewritten.
+- Install JS deps with `npm ci` and PHP dev tooling (PHPCS) with `composer install`.
+- This repo has no wp-env / Docker sandbox of its own. Develop against a WordPress install that already has an active, compatible Sensei LMS — e.g. the local site this checkout lives under.
+
+## Building
+- `npm run build` — full release build: `build:assets` then `archive` (produces `sensei-certificates.zip` via `composer archive`).
+- `npm run build:assets` — compile JS/CSS from `assets/` into `assets/dist/` (`wp-scripts build`). Run this after changing anything under `assets/`; the built files are what the browser loads.
+- `npm run start` — webpack watch mode for iterative asset work.
+- `npm run i18n:build` — regenerate `lang/sensei-certificates.pot` (needs `wp-cli`).
+
+## Testing
+- **Test-driven development**: Write tests for non-trivial new behavior and bug fixes — a failing test first, then implement until it passes. Skip tests only for trivial changes such as copy/string tweaks, config, mechanical renames, one-line passthroughs, and styling. If unsure whether a change needs a test, ask rather than skip by default.
+- **No harness is wired up yet** (no PHPUnit, Jest, or Playwright config in this repo). Standing up the appropriate runner is part of doing a change properly — add PHPUnit (the WordPress-plugin standard, as the `sensei` repo uses) for PHP behavior, or coordinate with the maintainer. Do not treat the missing harness as license to skip tests, and do not fabricate `make test` / `npm test` commands that don't exist.
+- **Ad-hoc UI verification**: For UI or behavior changes, use the `ui-verification` skill (`.claude/skills/ui-verification/SKILL.md`), which scopes from the diff and drives the running site via Chrome DevTools MCP. Requires a WordPress install with Sensei LMS active and a course a student can complete.
+
+## Linting
+- **PHPCS** (WordPress coding standards, config in `phpcs.xml.dist`): run `./vendor/bin/phpcs` after `composer install`. Auto-fix with `./vendor/bin/phpcbf`. `lib/`, `vendor/`, `node_modules/`, `build/`, and `tests/` are excluded. Enforced global prefixes are `sensei` and `woothemes`; text domain is `sensei-certificates`.
+- **JS**: `npm run lint:js` (ESLint via `wp-scripts` on `assets/js`). Format with `npm run format:js`.
+- **CSS/SCSS**: `npm run lint:css` (stylelint via `wp-scripts` on `assets/css`).
+- **package.json**: `npm run lint:pkg-json`.
+- There is no CI in this repo enforcing these, so run the relevant linters yourself before opening a PR.
+
+## Conventions
+- **Coding standards**: Follow the WordPress coding standards for the language you touch — [PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/). Use long-form `array( ... )` in new PHP.
+- **Naming — local exceptions to Sensei's conventions**: Follow Sensei LMS's naming conventions (linked under "Read before writing code") for new code, except where this repo's established patterns win: classes are prefixed `WooThemes_Sensei_` / `Woothemes_Sensei_`, and globals (functions, hooks) use the `sensei` / `woothemes` prefixes enforced by `phpcs.xml.dist`. Existing `learner`-based identifiers and DB keys (e.g. the `learner_id` post meta) can't be renamed — leave them. Do not rewrite surrounding code to match a new style.
+- **Documenting hooks and functions**: Give new or changed actions/filters and public functions a docblock (params, return, `@since`). For `@since`, use the version being released (there is no `$$next-version$$` placeholder tooling in this repo). When deprecating code, name the replacement in the docblock.
+- **Minimum supported versions**: The `woothemes-sensei-certificates.php` plugin header is the source of truth — `Requires PHP` (minimum PHP) and `Requires at least` (minimum WordPress). Keep it, `readme.txt`, and `SENSEI_CERTIFICATES_VERSION` in sync on a version bump. Don't use PHP features newer than the minimum.
+- **Version bumps**: Keep the version in sync across `woothemes-sensei-certificates.php` (header + `SENSEI_CERTIFICATES_VERSION`), `package.json`, and `readme.txt` (`Stable tag`).
+
+## Common pitfalls
+- **Editing the `sensei` source or `lib/tfpdf/` from this repo.** Both are effectively read-only here — fix Sensei LMS concerns upstream in `sensei`; treat tFPDF as vendored third-party code.
+- **Stale built assets**: changes under `assets/` don't appear in the browser until `npm run build:assets` (or `npm run start`) regenerates `assets/dist/`. Hard-reload after building.
+- **Assuming Sensei LMS APIs**: signatures for `Sensei()`, `Sensei_Assets`, `Sensei_Settings`, etc. live in the `sensei` repo — verify there instead of guessing.
+- **Forgetting the version-file sync** on a release (plugin header, `SENSEI_CERTIFICATES_VERSION`, `package.json`, `readme.txt`).
+- **Using the wrong Node**: run `nvm use` first so `package-lock.json` isn't rewritten by a newer npm.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
### Changes proposed in this Pull Request

Coding agents (Claude Code and others) had no repo-specific guidance for this plugin, so they fell back on assumptions — often borrowing tooling from the sibling `sensei` / `sensei-pro` repos that doesn't exist here. This adds:

- **AGENTS.md** (+ **CLAUDE.md** re-exporting it) — repo layout, the runtime Sensei LMS dependency, build/lint/test workflow, and conventions. Test and naming conventions link to Sensei LMS's canonical docs; local exceptions (legacy prefixes, `learner_id`) are called out.
- **`ui-verification` skill** — agent-driven browser verification via Chrome DevTools MCP, scoped from the diff to certificate surfaces. Manual verification, not an automated suite.
- **`pull-request` skill** — fills this repo's PR template from the diff, assigns the required milestone, and stops for approval before pushing.

Docs and agent tooling only — no plugin code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)