### PR TITLE
Defer View Certificate block registration to init

### DIFF
--- a/classes/blocks/class-woothemes-sensei-certificates-view-certificate-link-block.php
+++ b/classes/blocks/class-woothemes-sensei-certificates-view-certificate-link-block.php
@@ -18,6 +18,19 @@ class WooThemes_Sensei_Certificates_View_Certificate_Link_Block {
 	 * Sensei_Course_Overview_Block constructor.
 	 */
 	public function __construct() {
+		add_action( 'init', array( $this, 'register_block' ) );
+	}
+
+	/**
+	 * Register the block.
+	 *
+	 * Deferred to the `init` hook so that the block metadata (title, description)
+	 * in block.json is not translated before `init`, which would trigger a
+	 * `_load_textdomain_just_in_time` notice on WordPress 6.7+.
+	 *
+	 * @since 2.5.5
+	 */
+	public function register_block() {
 		Sensei_Blocks::register_sensei_block(
 			'sensei-certificates/view-certificate-link',
 			array(


### PR DESCRIPTION
### Changes proposed in this Pull Request

On WordPress 6.7+, admins see a `_load_textdomain_just_in_time was called incorrectly` notice. The View Certificate block was registered in its constructor, which runs on `plugins_loaded` (before `init`). Registering the block that early causes WordPress to translate the block's `title` and `description` from block.json before `init`, which triggers the notice.

This defers block registration to the `init` hook, so the block metadata is translated at the correct time and the notice no longer appears. Block behavior is unchanged.

### Testing instructions

1. Enable `WP_DEBUG` and `WP_DEBUG_LOG` on a site running WordPress 6.7+ with Sensei LMS active.
2. Before the fix: load any admin or front-end page and confirm a `_load_textdomain_just_in_time` notice mentioning `sensei-certificates` appears in the debug log.
3. With this branch active: reload — confirm the notice is gone.
4. Add the "View Certificate" block to a page, complete a course as a student, and confirm the block still renders the certificate link as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)