### PR TITLE
Fix unauthenticated certificate PII disclosure

### DIFF
--- a/classes/class-woothemes-sensei-certificates-tfpdf.php
+++ b/classes/class-woothemes-sensei-certificates-tfpdf.php
@@ -44,6 +44,10 @@ class Woothemes_Sensei_Certificates_TFPDF {
 	 * @param string     $filename The filename to send in the HTTP headers.
 	 */
 	public static function output_to_http( $tfpdf, $filename ) {
+		// Sanitize before interpolating into the header; the filename derives from the
+		// certificate hash meta, which could contain characters that break the header.
+		$filename = sanitize_file_name( $filename );
+
 		header( 'Content-Type: application/pdf' );
 		header( "Content-Disposition: inline; filename=\"$filename\"" );
 		header( 'Cache-Control: private, max-age=0, must-revalidate' );

--- a/classes/class-woothemes-sensei-certificates-tfpdf.php
+++ b/classes/class-woothemes-sensei-certificates-tfpdf.php
@@ -44,8 +44,6 @@ class Woothemes_Sensei_Certificates_TFPDF {
 	 * @param string     $filename The filename to send in the HTTP headers.
 	 */
 	public static function output_to_http( $tfpdf, $filename ) {
-		// Sanitize before interpolating into the header; the filename derives from the
-		// certificate hash meta, which could contain characters that break the header.
 		$filename = sanitize_file_name( $filename );
 
 		header( 'Content-Type: application/pdf' );

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -766,9 +766,6 @@ class WooThemes_Sensei_Certificates {
 	 * @return boolean
 	 */
 	public function can_view_certificate( $certificate_id = 0 ) {
-
-		global $post, $current_user;
-
 		$response = false;
 
 		if ( 0 >= intval( $certificate_id ) ) {
@@ -787,7 +784,6 @@ class WooThemes_Sensei_Certificates {
 		 * @since 1.9.0
 		 * @param bool $force_public_access default false
 		 */
-
 		$force_public_access = apply_filters( 'sensei_certificates_force_public_certs', false );
 
 		// If we can view certificates, get out.
@@ -795,13 +791,12 @@ class WooThemes_Sensei_Certificates {
 			return true;
 		}
 
-		if ( isset( $current_user->ID ) && ( intval( $current_user->ID ) === intval( $learner_id ) ) ) {
+		if ( is_user_logged_in() && ( get_current_user_id() === intval( $learner_id ) ) ) {
 			$response = true;
 		}
 
 		return $response;
-	} // End can_view_certificate()
-
+	}
 
 	/**
 	 * Download the certificate
@@ -811,7 +806,6 @@ class WooThemes_Sensei_Certificates {
 	 * @return void
 	 */
 	public function download_certificate() {
-
 		global $post;
 
 		if ( ! is_singular() || 'certificate' !== get_post_type() ) {
@@ -819,30 +813,27 @@ class WooThemes_Sensei_Certificates {
 		}
 
 		if ( $this->can_view_certificate( get_the_ID() ) ) {
-
-			$hash      = $post->post_slug;
+			$hash      = $post->post_name;
 			$hash_meta = get_post_meta( get_the_ID(), 'certificate_hash', true );
-			if ( ! empty( $hash_meta ) && 8 >= strlen( $hash_meta ) ) {
+
+			if ( ! empty( $hash_meta ) ) {
 				$hash = $hash_meta;
 			}
 
 			require_once 'class-woothemes-sensei-pdf-certificate.php';
-			$pdf = new WooThemes_Sensei_PDF_Certificate( $hash );
+
+			$pdf = new WooThemes_Sensei_PDF_Certificate( $hash, get_the_ID() );
 			$pdf->generate_pdf();
 			exit;
 
 		} elseif ( is_user_logged_in() ) {
-
 			wp_die( esc_html__( 'You are not allowed to view this Certificate.', 'sensei-certificates' ), esc_html__( 'Certificate Error', 'sensei-certificates' ) );
-
 		} else {
-
 			// Redirect to the login page.
 			wp_safe_redirect( wp_login_url( get_permalink() ) );
 			exit;
-
-		} // End If Statement
-	} // End generate_certificate()
+		}
+	}
 
 	/**
 	 * Replace template tags on certificate data fields.
@@ -900,6 +891,42 @@ class WooThemes_Sensei_Certificates {
 	}
 
 	/**
+	 * Resolve the certificate post ID for a PDF certificate object.
+	 *
+	 * Prefers the explicit certificate ID, falling back to a hash lookup. Skips the
+	 * lookup for an empty hash, which WP_Meta_Query would treat as matching every
+	 * certificate and resolve to the newest one on the site.
+	 *
+	 * @since 2.5.5
+	 * @param  WooThemes_Sensei_PDF_Certificate $pdf_certificate The PDF certificate object.
+	 * @return int The certificate post ID, or 0 when none can be resolved.
+	 */
+	private function get_certificate_id_for_pdf( $pdf_certificate ) {
+		if ( ! empty( $pdf_certificate->certificate_id ) ) {
+			return intval( $pdf_certificate->certificate_id );
+		}
+
+		if ( empty( $pdf_certificate->hash ) ) {
+			return 0;
+		}
+
+		$query = new WP_Query(
+			array(
+				'post_type'      => 'certificate',
+				'meta_key'       => 'certificate_hash', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value'     => $pdf_certificate->hash, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				'posts_per_page' => 1,
+			)
+		);
+
+		$certificate_id = $query->have_posts() ? intval( $query->posts[0]->ID ) : 0;
+
+		wp_reset_postdata();
+
+		return $certificate_id;
+	}
+
+	/**
 	 * Add text to the certificate
 	 *
 	 * @access public
@@ -913,26 +940,9 @@ class WooThemes_Sensei_Certificates {
 		$show_border    = apply_filters( 'woothemes_sensei_certificates_show_border', 0 );
 		$start_position = 200;
 
-		// Find certificate based on hash.
-		$args = array(
-			'post_type'  => 'certificate',
-			'meta_key'   => 'certificate_hash',
-			'meta_value' => $pdf_certificate->hash,
-		);
+		$certificate_id = $this->get_certificate_id_for_pdf( $pdf_certificate );
 
-		$query          = new WP_Query( $args );
-		$certificate_id = 0;
-
-		if ( $query->have_posts() ) {
-
-			$query->the_post();
-			$certificate_id = $query->posts[0]->ID;
-
-		} // End If Statement
-
-		wp_reset_postdata();
-
-		if ( 0 < intval( $certificate_id ) ) {
+		if ( 0 < $certificate_id ) {
 
 			$user_id = get_post_meta( $certificate_id, 'learner_id', true );
 			$student = get_userdata( $user_id );
@@ -1037,22 +1047,11 @@ class WooThemes_Sensei_Certificates {
 
 		$start_position = 200;
 
-		// Find certificate based on hash.
-		$args = array(
-			'post_type'  => 'certificate',
-			'meta_key'   => 'certificate_hash',
-			'meta_value' => $pdf_certificate->hash,
-		);
+		$certificate_id = $this->get_certificate_id_for_pdf( $pdf_certificate );
 
-		$query = new WP_Query( $args );
-		if ( $query->have_posts() ) {
-
-			$query->the_post();
-			$certificate_id = $query->posts[0]->ID;
-
-		} // End If Statement
-
-		wp_reset_postdata();
+		if ( 0 >= $certificate_id ) {
+			return;
+		}
 
 		$course_id = get_post_meta( $certificate_id, 'course_id', true );
 

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -772,11 +772,13 @@ class WooThemes_Sensei_Certificates {
 			return false; // We require a certificate ID value.
 		}
 
-		$learner_id = get_post_meta( intval( $certificate_id ), 'learner_id', true );
+		$learner_id = absint( get_post_meta( intval( $certificate_id ), 'learner_id', true ) );
 
-		// Check if student can only view certificate.
+		// Check if student can only view certificate. Only read the owner's public-view
+		// option for a real learner; passing 0 makes get_user_option() fall back to the
+		// current user, which would leak an ownerless certificate on a public-certs site.
 		$grant_access      = Sensei()->settings->settings['certificates_public_viewable'];
-		$grant_access_user = get_user_option( 'sensei_certificates_view_by_public', $learner_id );
+		$grant_access_user = $learner_id ? get_user_option( 'sensei_certificates_view_by_public', $learner_id ) : false;
 
 		/**
 		 * Filter to force all certificates to be public.
@@ -791,7 +793,7 @@ class WooThemes_Sensei_Certificates {
 			return true;
 		}
 
-		if ( is_user_logged_in() && ( get_current_user_id() === intval( $learner_id ) ) ) {
+		if ( is_user_logged_in() && ( get_current_user_id() === $learner_id ) ) {
 			$response = true;
 		}
 

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -774,9 +774,7 @@ class WooThemes_Sensei_Certificates {
 
 		$learner_id = absint( get_post_meta( intval( $certificate_id ), 'learner_id', true ) );
 
-		// Check if student can only view certificate. Only read the owner's public-view
-		// option for a real learner; passing 0 makes get_user_option() fall back to the
-		// current user, which would leak an ownerless certificate on a public-certs site.
+		// Check if student can only view certificate.
 		$grant_access      = Sensei()->settings->settings['certificates_public_viewable'];
 		$grant_access_user = $learner_id ? get_user_option( 'sensei_certificates_view_by_public', $learner_id ) : false;
 

--- a/classes/class-woothemes-sensei-pdf-certificate.php
+++ b/classes/class-woothemes-sensei-pdf-certificate.php
@@ -46,7 +46,7 @@ class WooThemes_Sensei_PDF_Certificate {
 	/**
 	 * Certificate hash.
 	 *
-	 * @var int
+	 * @var string
 	 */
 	public $hash;
 
@@ -83,9 +83,9 @@ class WooThemes_Sensei_PDF_Certificate {
 	 *
 	 * @access public
 	 * @since 1.0.0
-	 * @param int $certificate_hash Certificate hash.
-	 * @param int $certificate_id   Certificate post ID. Optional; when set, rendering
-	 *                              resolves from it instead of re-querying by hash.
+	 * @param string $certificate_hash Certificate hash.
+	 * @param int    $certificate_id   Certificate post ID. Optional; when set, rendering
+	 *                                 resolves from it instead of re-querying by hash.
 	 */
 	public function __construct( $certificate_hash, $certificate_id = 0 ) {
 

--- a/classes/class-woothemes-sensei-pdf-certificate.php
+++ b/classes/class-woothemes-sensei-pdf-certificate.php
@@ -51,6 +51,13 @@ class WooThemes_Sensei_PDF_Certificate {
 	public $hash;
 
 	/**
+	 * Certificate post ID.
+	 *
+	 * @var int
+	 */
+	public $certificate_id;
+
+	/**
 	 * Certificate PDF data.
 	 *
 	 * @var mixed
@@ -77,10 +84,13 @@ class WooThemes_Sensei_PDF_Certificate {
 	 * @access public
 	 * @since 1.0.0
 	 * @param int $certificate_hash Certificate hash.
+	 * @param int $certificate_id   Certificate post ID. Optional; when set, rendering
+	 *                              resolves from it instead of re-querying by hash.
 	 */
-	public function __construct( $certificate_hash ) {
+	public function __construct( $certificate_hash, $certificate_id = 0 ) {
 
-		$this->hash = $certificate_hash;
+		$this->hash           = $certificate_hash;
+		$this->certificate_id = intval( $certificate_id );
 
 		$this->certificate_pdf_data = apply_filters(
 			'woothemes_sensei_certificates_pdf_data',


### PR DESCRIPTION
### Changes proposed in this Pull Request

Fixes [SEN-173](https://linear.app/a8c/issue/SEN-173/certificates-unauthenticated-pii-disclosure-empty-learner-id-passes).

On Sensei LMS Certificates 2.5.4, two defects combined to serve a real learner's certificate PDF — full name, course title, completion date — to an unauthenticated visitor with Public Certificate turned off, and to serve the same (newest) certificate for every certificate permalink on the site.

* **Unauthenticated access.** `can_view_certificate()` compared the visitor's user ID against the certificate's `learner_id` with a loose zero match. For a certificate whose `learner_id` meta was missing or empty, an anonymous visitor (user ID `0`) matched (`0 === 0`) and was granted access, bypassing the public-certificate setting. The ownership check now requires a logged-in user and a strict comparison against a non-zero learner ID; the admin and force-public grants are unchanged.
* **Wrong certificate rendered.** The download read the hash from a nonexistent `WP_Post::post_slug` property, which silently returned an empty string. An empty hash was then passed to a `WP_Query`, where WordPress drops an empty `meta_value` — so the lookup matched every certificate and rendered the most recently issued one regardless of the requested URL. Rendering now resolves the certificate from the requested post ID directly, reads the slug from `post_name`, and never runs the hash lookup for an empty hash.
* **Hardening (review follow-ups).** Coerce `learner_id` and skip the owner's public-view lookup when it is empty, so an ownerless certificate can't inherit the current visitor's public setting on a public-certs site. Sanitize the PDF filename before it is written to the `Content-Disposition` header.

### Changelog

* Fix: Prevent unauthenticated access to certificates with a missing learner
* Fix: Render the requested certificate instead of the most recent one

### Testing instructions

- [x] Ensure **Sensei LMS → Settings → Certificates → Public Certificate** is OFF.
- [x] Complete a course as Student A, then complete it as Student B a little later, so two `certificate` posts exist with different learners.
- [x] On Student A's certificate, enable **Custom Fields** (editor Preferences → Panels) and delete the `learner_id` meta.
- [x] Log out, visit `/certificate/<A-slug>/`, and confirm you are redirected to the login page (before this fix, a PDF was served with no login).
- [x] Restore `learner_id`, set A's `certificate_hash` meta to a value longer than 8 characters (or delete it), log in as an admin, view A's certificate, and confirm the PDF shows Student A (before this fix, it showed Student B — the newest certificate).
- [x] Complete a course normally and confirm the certificate still renders, downloads as a PDF, and the "View Certificate" link/block appears for the owner.
