### PR TITLE
Fix PHP notices and deprecation for orphaned certificates

### DIFF
--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -850,17 +850,24 @@ class WooThemes_Sensei_Certificates {
 	 */
 	public function replace_data_field_template_tags( $field_value, $field_key, $student, $course = null ) {
 		// Prepare data.
-		if ( $course && $student instanceof WP_User && $student->ID > 0 ) {
+		if ( $course instanceof WP_Post ) {
 			$course_title    = $course->post_title;
-			$course_end      = Sensei_Utils::sensei_check_for_activity(
-				array(
-					'post_id' => $course->ID,
-					'user_id' => $student->ID,
-					'type'    => 'sensei_course_status',
-				),
-				true
-			);
-			$course_end_date = $course_end ? $course_end->comment_date : gmdate( 'Y-m-d' );
+			$course_end_date = '';
+
+			if ( $student instanceof WP_User ) {
+				$course_end = Sensei_Utils::sensei_check_for_activity(
+					array(
+						'post_id' => $course->ID,
+						'user_id' => $student->ID,
+						'type'    => 'sensei_course_status',
+					),
+					true
+				);
+
+				if ( $course_end ) {
+					$course_end_date = $course_end->comment_date;
+				}
+			}
 		} else {
 			// Most likely this is for preview. Use placeholder data.
 			$course_title    = __( 'Course Title', 'sensei-certificates' );

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -960,8 +960,6 @@ class WooThemes_Sensei_Certificates {
 			$course_id = get_post_meta( $certificate_id, 'course_id', true );
 			$course    = get_post( $course_id );
 
-			// The completion date is resolved per data field in
-			// replace_data_field_template_tags(), so no activity lookup is needed here.
 			$certificate_template_id = get_post_meta( $course_id, '_course_certificate_template', true );
 
 			$certificate_template_custom_fields = get_post_custom( $certificate_template_id );

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -854,7 +854,7 @@ class WooThemes_Sensei_Certificates {
 			$course_title    = $course->post_title;
 			$course_end_date = '';
 
-			if ( $student instanceof WP_User ) {
+			if ( $student instanceof WP_User && $student->ID > 0 ) {
 				$course_end = Sensei_Utils::sensei_check_for_activity(
 					array(
 						'post_id' => $course->ID,

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -950,24 +950,24 @@ class WooThemes_Sensei_Certificates {
 			$user_id = get_post_meta( $certificate_id, 'learner_id', true );
 			$student = get_userdata( $user_id );
 
+			// A certificate with no resolvable learner (e.g. the student's user
+			// account was deleted, or the learner_id meta is missing) proves nothing
+			// and cannot be rendered meaningfully, so refuse it.
+			if ( ! $student instanceof WP_User ) {
+				wp_die( esc_html__( 'The certificate you are searching for does not exist.', 'sensei-certificates' ), esc_html__( 'Certificate Error', 'sensei-certificates' ) );
+			}
+
 			$course_id       = get_post_meta( $certificate_id, 'course_id', true );
 			$course          = get_post( $course_id );
-			$course_end_date = '';
-
-			if ( intval( $user_id ) > 0 ) {
-				$course_end = Sensei_Utils::sensei_check_for_activity(
-					array(
-						'post_id' => intval( $course_id ),
-						'user_id' => intval( $user_id ),
-						'type'    => 'sensei_course_status',
-					),
-					true
-				);
-
-				if ( $course_end ) {
-					$course_end_date = $course_end->comment_date;
-				}
-			}
+			$course_end      = Sensei_Utils::sensei_check_for_activity(
+				array(
+					'post_id' => intval( $course_id ),
+					'user_id' => $student->ID,
+					'type'    => 'sensei_course_status',
+				),
+				true
+			);
+			$course_end_date = $course_end ? $course_end->comment_date : '';
 
 			$certificate_template_id = get_post_meta( $course_id, '_course_certificate_template', true );
 

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -868,9 +868,12 @@ class WooThemes_Sensei_Certificates {
 		}
 
 		// Get student name.
-		$student_name = $student->display_name;
-		if ( $student->first_name && $student->last_name ) {
-			$student_name = $student->first_name . ' ' . $student->last_name;
+		$student_name = '';
+		if ( $student instanceof WP_User ) {
+			$student_name = $student->display_name;
+			if ( $student->first_name && $student->last_name ) {
+				$student_name = $student->first_name . ' ' . $student->last_name;
+			}
 		}
 
 		// Get end date.

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -957,18 +957,11 @@ class WooThemes_Sensei_Certificates {
 				wp_die( esc_html__( 'The certificate you are searching for does not exist.', 'sensei-certificates' ), esc_html__( 'Certificate Error', 'sensei-certificates' ) );
 			}
 
-			$course_id       = get_post_meta( $certificate_id, 'course_id', true );
-			$course          = get_post( $course_id );
-			$course_end      = Sensei_Utils::sensei_check_for_activity(
-				array(
-					'post_id' => intval( $course_id ),
-					'user_id' => $student->ID,
-					'type'    => 'sensei_course_status',
-				),
-				true
-			);
-			$course_end_date = $course_end ? $course_end->comment_date : '';
+			$course_id = get_post_meta( $certificate_id, 'course_id', true );
+			$course    = get_post( $course_id );
 
+			// The completion date is resolved per data field in
+			// replace_data_field_template_tags(), so no activity lookup is needed here.
 			$certificate_template_id = get_post_meta( $course_id, '_course_certificate_template', true );
 
 			$certificate_template_custom_fields = get_post_custom( $certificate_template_id );

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -850,7 +850,7 @@ class WooThemes_Sensei_Certificates {
 	 */
 	public function replace_data_field_template_tags( $field_value, $field_key, $student, $course = null ) {
 		// Prepare data.
-		if ( $course ) {
+		if ( $course && $student instanceof WP_User && $student->ID > 0 ) {
 			$course_title    = $course->post_title;
 			$course_end      = Sensei_Utils::sensei_check_for_activity(
 				array(
@@ -860,7 +860,7 @@ class WooThemes_Sensei_Certificates {
 				),
 				true
 			);
-			$course_end_date = $course_end->comment_date;
+			$course_end_date = $course_end ? $course_end->comment_date : gmdate( 'Y-m-d' );
 		} else {
 			// Most likely this is for preview. Use placeholder data.
 			$course_title    = __( 'Course Title', 'sensei-certificates' );
@@ -949,15 +949,22 @@ class WooThemes_Sensei_Certificates {
 
 			$course_id       = get_post_meta( $certificate_id, 'course_id', true );
 			$course          = get_post( $course_id );
-			$course_end      = Sensei_Utils::sensei_check_for_activity(
-				array(
-					'post_id' => intval( $course_id ),
-					'user_id' => intval( $user_id ),
-					'type'    => 'sensei_course_status',
-				),
-				true
-			);
-			$course_end_date = $course_end->comment_date;
+			$course_end_date = '';
+
+			if ( intval( $user_id ) > 0 ) {
+				$course_end = Sensei_Utils::sensei_check_for_activity(
+					array(
+						'post_id' => intval( $course_id ),
+						'user_id' => intval( $user_id ),
+						'type'    => 'sensei_course_status',
+					),
+					true
+				);
+
+				if ( $course_end ) {
+					$course_end_date = $course_end->comment_date;
+				}
+			}
 
 			$certificate_template_id = get_post_meta( $course_id, '_course_certificate_template', true );
 

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -647,6 +647,11 @@ class WooThemes_Sensei_Certificates {
 
 		switch ( $column_name ) {
 			case 'learner':
+				if ( ! $user instanceof WP_User ) {
+					echo '-';
+					break;
+				}
+
 				echo '<a href="' . esc_url(
 					add_query_arg(
 						array(


### PR DESCRIPTION
### Changes proposed in this Pull Request

Generating or rendering a certificate that has no resolvable learner — an orphaned certificate whose student account was deleted or whose `learner_id` meta is missing, so `get_userdata()` returns `false` — passed a `user_id` of `0` into `Sensei_Utils::sensei_check_for_activity()`. Sensei LMS treats that as invalid and emitted a `_deprecated_argument` notice ("At no point should user_id be equal to 0."), and the surrounding code then read properties off non-object values (`comment_date`, `display_name`, `first_name`), producing a run of PHP notices and a meaningless PDF with a blank name and placeholder course data.

Such a certificate certifies nobody, so `certificate_text()` now refuses it up front with the same "does not exist" error already used for a missing certificate. As a side effect, a resolved learner guarantees a non-zero `user_id` for the activity lookup. `replace_data_field_template_tags()` is also hardened defensively for the preview path and third-party callers of the `sensei_certificate_data_field_value` filter. The learner column of the certificates admin list table is likewise guarded so a deleted user shows a dash instead of emitting notices.

### Changelog

* Fix: Prevent PHP notices and a Sensei deprecation warning when viewing or rendering a certificate whose learner no longer exists.

### Testing instructions

- [x] Enable `WP_DEBUG` and `WP_DEBUG_LOG`.
- [x] As a student, complete a course that awards a certificate.
- [x] View and download the certificate PDF — it renders with the correct name, course, and completion date, and no PHP notices appear in the debug log.
- [x] Delete the student's user account to orphan their certificate, then open that certificate — it shows the "certificate you are searching for does not exist" error rather than a PDF.
- [ ] With that student's account still deleted, open Certificates in the admin (wp-admin) and confirm the orphaned certificate's Learner column shows a dash with no PHP notices in the debug log.
- [x] Confirm no "At no point should user_id be equal to 0" or "Trying to get property of non-object" notices appear in the debug log for either case.