### PR TITLE
Add PHP linting workflow for pull requests

### DIFF
--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -1,0 +1,39 @@
+name: PHP Linting
+
+on:
+    pull_request:
+
+concurrency:
+    group: php-lint-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
+    cancel-in-progress: true
+
+jobs:
+    lint:
+        name: PHP Linting
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Get cached composer directories
+              uses: actions/cache@v4
+              with:
+                  path: ~/.cache/composer/
+                  key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+            - uses: actions/cache@v4
+              with:
+                  path: vendor/
+                  key: ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+              with:
+                  php-version: '7.4'
+                  tools: composer
+                  coverage: none
+
+            - name: Install PHP dependencies
+              run: composer install --no-ansi --no-interaction --prefer-dist --no-progress
+
+            - name: Run PHPCS
+              run: ./vendor/bin/phpcs

--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -36,4 +36,4 @@ jobs:
               run: composer install --no-ansi --no-interaction --prefer-dist --no-progress
 
             - name: Run PHPCS
-              run: ./vendor/bin/phpcs
+              run: npm run lint:php

--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -13,14 +13,14 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
             - name: Get cached composer directories
-              uses: actions/cache@v4
+              uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
               with:
                   path: ~/.cache/composer/
                   key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-            - uses: actions/cache@v4
+            - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
               with:
                   path: vendor/
                   key: ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "format:js": "wp-scripts format-js",
     "lint:css": "wp-scripts lint-style assets/css",
     "lint:js": "wp-scripts lint-js assets/js",
+    "lint:php": "vendor/bin/phpcs",
     "lint:pkg-json": "wp-scripts lint-pkg-json",
     "packages-update": "wp-scripts packages-update",
     "start": "wp-scripts start",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "check-engines": "wp-scripts check-engines",
     "check-licenses": "wp-scripts check-licenses",
     "format:js": "wp-scripts format-js",
+    "format:php": "vendor/bin/phpcbf",
     "lint:css": "wp-scripts lint-style assets/css",
     "lint:js": "wp-scripts lint-js assets/js",
     "lint:php": "vendor/bin/phpcs",


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Adds a GitHub Actions workflow that runs PHPCS on every pull request, so coding-standard regressions are caught in CI instead of by hand. The job installs Composer dev dependencies (with cached `~/.cache/composer` and `vendor/`), sets up PHP 7.4 to match the `phpcs.xml.dist` floor, and runs `./vendor/bin/phpcs` over the whole codebase using the repo's existing ruleset.

### Testing instructions

* [x] Confirm the **PHP Linting** check runs and passes on this PR.