### PR TITLE
Deprecate legacy data-update registration

### DIFF
--- a/classes/blocks/class-woothemes-sensei-certificates-view-certificate-link-block.php
+++ b/classes/blocks/class-woothemes-sensei-certificates-view-certificate-link-block.php
@@ -28,7 +28,7 @@ class WooThemes_Sensei_Certificates_View_Certificate_Link_Block {
 	 * in block.json is not translated before `init`, which would trigger a
 	 * `_load_textdomain_just_in_time` notice on WordPress 6.7+.
 	 *
-	 * @since 2.5.5
+	 * @since 2.6.0
 	 */
 	public function register_block() {
 		Sensei_Blocks::register_sensei_block(

--- a/classes/class-woothemes-sensei-certificates-dependency-checker.php
+++ b/classes/class-woothemes-sensei-certificates-dependency-checker.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Woothemes_Sensei_Certificates_Dependency_Checker {
 	const MINIMUM_PHP_VERSION    = '7.2';
-	const MINIMUM_SENSEI_VERSION = '1.11.0';
+	const MINIMUM_SENSEI_VERSION = '3.6.1';
 
 
 	/**

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -220,8 +220,6 @@ class WooThemes_Sensei_Certificates {
 			add_action( 'sensei_analysis_course_columns', array( $instance, 'create_columns' ), 10, 2 );
 			add_action( 'sensei_analysis_course_column_data', array( $instance, 'populate_columns' ), 10, 3 );
 			add_filter( 'sensei_scripts_allowed_post_types', array( $instance, 'include_sensei_scripts' ), 10, 1 );
-			add_filter( 'sensei_upgrade_functions', 'sensei_certificates_updates_list', 10, 1 );
-			add_filter( 'sensei_updates_function_whitelist', 'sensei_certificates_add_update_functions_to_whitelist', 1 );
 
 			// We don't need a WordPress SEO meta box for certificates and certificate templates. Hide it.
 			add_filter( 'option_wpseo_titles', array( $instance, 'force_hide_wpseo_meta_box' ) );

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -83,7 +83,7 @@ class WooThemes_Sensei_Certificates {
 	 * Inline JS code.
 	 *
 	 * @var string
-	 * @deprecated 2.5.5
+	 * @deprecated 2.6.0
 	 */
 	public $_inline_js; // phpcs:ignore PSR2.Classes.PropertyDeclaration.Underscore -- Deprecated public property; renaming would break backward compatibility.
 
@@ -888,7 +888,7 @@ class WooThemes_Sensei_Certificates {
 	/**
 	 * Get a student's completion date for a course.
 	 *
-	 * @since 2.5.5
+	 * @since 2.6.0
 	 *
 	 * @param int $course_id Course post ID.
 	 * @param int $user_id   Student user ID.
@@ -911,7 +911,7 @@ class WooThemes_Sensei_Certificates {
 	 * lookup for an empty hash, which WP_Meta_Query would treat as matching every
 	 * certificate and resolve to the newest one on the site.
 	 *
-	 * @since 2.5.5
+	 * @since 2.6.0
 	 * @param  WooThemes_Sensei_PDF_Certificate $pdf_certificate The PDF certificate object.
 	 * @return int The certificate post ID, or 0 when none can be resolved.
 	 */
@@ -1396,14 +1396,14 @@ class WooThemes_Sensei_Certificates {
 	 *
 	 * @access public
 	 * @since  1.0.7
-	 * @deprecated 2.5.5 Certificates are preserved when progress is reset; no replacement.
+	 * @deprecated 2.6.0 Certificates are preserved when progress is reset; no replacement.
 	 *
 	 * @param  int $user_id   User ID.
 	 * @param  int $lesson_id Lesson Post ID.
 	 * @return void
 	 */
 	public function reset_lesson_course_certificate( $user_id = 0, $lesson_id = 0 ) {
-		_deprecated_function( __METHOD__, '2.5.5' );
+		_deprecated_function( __METHOD__, '2.6.0' );
 
 		if ( 0 < $user_id && 0 < $lesson_id ) {
 			$course_id = get_post_meta( $lesson_id, '_lesson_course', true );
@@ -1418,14 +1418,14 @@ class WooThemes_Sensei_Certificates {
 	 *
 	 * @access public
 	 * @since  1.0.0
-	 * @deprecated 2.5.5 Certificates are preserved when progress is reset; no replacement.
+	 * @deprecated 2.6.0 Certificates are preserved when progress is reset; no replacement.
 	 *
 	 * @param  int $user_id   User ID.
 	 * @param  int $course_id Course Post ID.
 	 * @return void
 	 */
 	public function reset_course_certificate( $user_id = 0, $course_id = 0 ) {
-		_deprecated_function( __METHOD__, '2.5.5' );
+		_deprecated_function( __METHOD__, '2.6.0' );
 
 		if ( 0 < $user_id && 0 < $course_id ) {
 

--- a/sensei-certificates-functions.php
+++ b/sensei-certificates-functions.php
@@ -10,13 +10,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Function sensei_certificates_updates_list add sensei certificates updates to sensei list.
+ * Add Sensei Certificates data updates to the Sensei updates list.
  *
  * @since  1.0.0
+ * @deprecated 2.6.0 Sensei LMS no longer runs legacy data updates; no replacement.
+ *
  * @param  array $updates List of existing updates.
- * @return array $updates List of existing and new updates.
+ * @return array List of existing and new updates.
  */
 function sensei_certificates_updates_list( $updates ) {
+	_deprecated_function( __FUNCTION__, '2.6.0' );
 
 	$updates['1.0.0'] = array(
 		'auto'   => array(),
@@ -38,12 +41,16 @@ function sensei_certificates_updates_list( $updates ) {
 }
 
 /**
- * Function sensei_certificates_add_update_functions_to_whitelist.
+ * Add Sensei Certificates update functions to the permitted list.
+ *
+ * @deprecated 2.6.0 Sensei LMS no longer runs legacy data updates; no replacement.
  *
  * @param  array $permitted_functions Permitted functions.
  * @return array
  */
 function sensei_certificates_add_update_functions_to_whitelist( $permitted_functions ) {
+	_deprecated_function( __FUNCTION__, '2.6.0' );
+
 	return array_merge(
 		$permitted_functions,
 		array(


### PR DESCRIPTION
### Changes proposed in this Pull Request

Sensei LMS stopped consuming the `sensei_upgrade_functions` and `sensei_updates_function_whitelist` filters in 3.6.1 (Automattic/sensei#3842), so this plugin's registration of them has been dead against every supported Sensei version. This removes the two dead `add_filter` registrations and marks the two now-unused functions deprecated, keeping them as back-compat stubs.

Also corrects seven SEN-127 (#379) version tags that were mistakenly set to 2.5.5; the next release is 2.6.0.

### Changelog

Tweak: Deprecate the unused legacy data-update registration functions

### Deprecated Code

* `sensei_certificates_updates_list()` — no replacement; Sensei LMS no longer runs legacy data updates.
* `sensei_certificates_add_update_functions_to_whitelist()` — no replacement.