### PR TITLE
Sync MINIMUM_PHP_VERSION with plugin header

### DIFF
--- a/classes/class-woothemes-sensei-certificates-dependency-checker.php
+++ b/classes/class-woothemes-sensei-certificates-dependency-checker.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 2.0.0
  */
 class Woothemes_Sensei_Certificates_Dependency_Checker {
-	const MINIMUM_PHP_VERSION    = '7.2';
+	const MINIMUM_PHP_VERSION    = '7.4';
 	const MINIMUM_SENSEI_VERSION = '3.6.1';
 
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

Bump the dependency checker's `MINIMUM_PHP_VERSION` from 7.2 to 7.4 to match the plugin header (`Requires PHP: 7.4`), the source of truth.