### PR TITLE
Move GitHub Actions Dependabot updates to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,8 +54,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "friday"
+      interval: "monthly"
     open-pull-requests-limit: 10
     groups:
       actions-minor-patch:


### PR DESCRIPTION
Move GitHub Actions Dependabot updates from weekly to monthly. npm and Composer stay weekly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)