### PR TITLE
Bump minimum Sensei LMS version to 3.7.0

### DIFF
--- a/changelog/fix-bump-minimum-sensei-3-7-0
+++ b/changelog/fix-bump-minimum-sensei-3-7-0
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Raise the minimum supported Sensei LMS version to 3.7.0 to prevent a fatal error on sites running an older Sensei.
+Raise the minimum supported Sensei LMS version to 3.7.0.

--- a/changelog/fix-bump-minimum-sensei-3-7-0
+++ b/changelog/fix-bump-minimum-sensei-3-7-0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Raise the minimum supported Sensei LMS version to 3.7.0 to prevent a fatal error on sites running an older Sensei.

--- a/classes/class-woothemes-sensei-certificates-dependency-checker.php
+++ b/classes/class-woothemes-sensei-certificates-dependency-checker.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Woothemes_Sensei_Certificates_Dependency_Checker {
 	const MINIMUM_PHP_VERSION    = '7.4';
-	const MINIMUM_SENSEI_VERSION = '3.6.1';
+	const MINIMUM_SENSEI_VERSION = '3.7.0';
 
 
 	/**


### PR DESCRIPTION
Fixes #321
Fixes #295

### Changes proposed in this Pull Request

On sites running an older Sensei LMS, this plugin can fatal in two places: it calls `Sensei_Utils::get_current_course()`, which first shipped in Sensei LMS 3.7.0 (#321), and it instantiates `Sensei_Assets` to enqueue the block editor assets, available since Sensei LMS 3.1.0 (#295). On a Sensei version below those, the site hits an undefined method / `enqueue()` on `null` and goes down.

This raises `MINIMUM_SENSEI_VERSION` to 3.7.0 — the higher of the two floors, which guarantees both APIs are present. On an unsupported Sensei version the dependency checker now short-circuits loading and shows an admin notice, so the plugin stays inert instead of loading and fataling. (Consistent with the existing behavior for the Sensei dependency, the plugin shows a notice rather than deactivating itself — unlike the PHP-version check, which does self-deactivate.)