### PR TITLE
Don't generate blank certificates for courses without a template

### DIFF
--- a/changelog/fix-no-blank-certificate-without-template
+++ b/changelog/fix-no-blank-certificate-without-template
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stop generating blank certificates for courses that have no certificate template assigned.

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -682,7 +682,7 @@ class WooThemes_Sensei_Certificates {
 					echo wp_kses_post(
 						sprintf(
 							// translators: %1$s is the URL for editing the Course.
-							__( 'Set a certificate template on the <a href="%1$s">course</a> in order to view this certificate', 'sensei-certificates' ),
+							__( 'Set a certificate template for the <a href="%1$s">course</a> in order to view this certificate', 'sensei-certificates' ),
 							esc_url( get_edit_post_link( $course_id ) )
 						)
 					);
@@ -733,6 +733,12 @@ class WooThemes_Sensei_Certificates {
 		if ( null === get_post( $course_id ) ) {
 			return;
 		}
+
+		// Don't generate a certificate for a course that has no certificate template assigned.
+		if ( ! get_post_meta( $course_id, '_course_certificate_template', true ) ) {
+			return;
+		}
+
 		$data_store = new Woothemes_Sensei_Certificate_Data_Store();
 
 		$certificate_id = $data_store->insert( $user_id, $course_id );


### PR DESCRIPTION
Fixes #363

### Changes proposed in this Pull Request

The plugin created a certificate on every course completion, even for courses with no certificate template assigned. Those render blank and pile up in the database.

This guards creation on the course's `_course_certificate_template` meta — only generating a certificate when a template is assigned, matching how the View Certificate block and admin column already treat an unset template. Also rewords the admin-column notice from "on the course" to "for the course".

Cleaning up existing blank certificates is out of scope.

### Testing instructions

1. Complete a course (as a student) that has **no** template assigned. Confirm **no** certificate is created under **Certificates**.
2. Assign a template to another course, complete it. Confirm a certificate **is** created, the "View Certificate" link appears, and the PDF renders.
3. For a template-less course, confirm the admin column notice reads "Set a certificate template **for** the course…".