### PR TITLE
Decode HTML entities in certificate text

### DIFF
--- a/changelog/fix-decode-html-entities-in-certificate-text
+++ b/changelog/fix-decode-html-entities-in-certificate-text
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Decode HTML entities and strip tags in certificate text so a course title containing markup (such as &nbsp;) no longer renders literally in the PDF.

--- a/changelog/fix-decode-html-entities-in-certificate-text
+++ b/changelog/fix-decode-html-entities-in-certificate-text
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Decode HTML entities and strip tags in certificate text so a course title containing markup (such as &nbsp;) no longer renders literally in the PDF.
+Decode HTML entities and strip tags in certificate text fields so markup no longer renders literally in the PDF.

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -894,9 +894,9 @@ class WooThemes_Sensei_Certificates {
 	/**
 	 * Decode HTML entities and strip tags from text bound for the certificate PDF.
 	 *
-	 * The PDF renderer (tFPDF) outputs plain text, so any HTML entities (e.g.
-	 * &nbsp;) or tags present in the source content would otherwise be printed
-	 * literally on the certificate.
+	 * The PDF renderer (tFPDF) outputs plain text, so any HTML entities or tags
+	 * present in the source content would otherwise be printed literally on the
+	 * certificate.
 	 *
 	 * @since 2.6.0
 	 *

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -878,10 +878,10 @@ class WooThemes_Sensei_Certificates {
 			: Woothemes_Sensei_Certificates_Utils::get_certificate_formatted_date( $course_end_date );
 
 		$replacement_values = array(
-			'{{learner}}'         => $student_name,
-			'{{course_title}}'    => $course_title,
+			'{{learner}}'         => $this->clean_pdf_text( $student_name ),
+			'{{course_title}}'    => $this->clean_pdf_text( $course_title ),
 			'{{completion_date}}' => $completion_date,
-			'{{course_place}}'    => get_bloginfo( 'name' ),
+			'{{course_place}}'    => $this->clean_pdf_text( get_bloginfo( 'name' ) ),
 		);
 
 		return str_replace(
@@ -889,6 +889,22 @@ class WooThemes_Sensei_Certificates {
 			array_values( $replacement_values ),
 			$field_value
 		);
+	}
+
+	/**
+	 * Decode HTML entities and strip tags from text bound for the certificate PDF.
+	 *
+	 * The PDF renderer (tFPDF) outputs plain text, so any HTML entities (e.g.
+	 * &nbsp;) or tags present in the source content would otherwise be printed
+	 * literally on the certificate.
+	 *
+	 * @since 2.6.0
+	 *
+	 * @param string $text The raw text.
+	 * @return string The decoded, tag-free text.
+	 */
+	private function clean_pdf_text( $text ) {
+		return wp_strip_all_tags( html_entity_decode( (string) $text, ENT_QUOTES, 'UTF-8' ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #284.

### Changes proposed in this Pull Request

Certificate template tags were substituted with raw content, so a course title containing HTML entities or tags printed literally on the PDF (tFPDF renders plain text only).

The tag values (`{{course_title}}`, `{{learner}}`, `{{course_place}}`) now pass through `html_entity_decode()` + `wp_strip_all_tags()` before substitution, so entities resolve and tags are removed.

### Testing instructions

Give a course a title whose stored value contains literal markup:

- [x] **Classic editor** — with the Classic Editor active, type the title directly, e.g. `Le juriste et la copropriété&nbsp;: <em>suite</em>` (the classic title field keeps it literal; the block editor would strip it).

Then:

- [x] Assign a certificate template to that course and complete it as a student.
- [x] View the certificate — confirm the title reads `Le juriste et la copropriété : suite`, with no literal `&nbsp;` and no `<em>` tags.
- [x] (Before this change, the same certificate shows the literal `&nbsp;` and `<em>`.)