### PR TITLE
Document changelogger and PHP linting in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,10 +18,11 @@ Apply them to code you add. Do not rewrite surrounding code to match. Where they
 - `admin/` — admin post-type UI and write panels for the certificate template designer.
 - `assets/` — JS/SCSS source and blocks; built artifacts land in `assets/dist/` (git-ignored, produced by the build).
 - `templates/` — front-end certificate templates (overridable by themes).
-- `lib/tfpdf/` — vendored tFPDF PDF library. Treat as read-only third-party code; excluded from linting.
+- `lib/tfpdf/` — vendored [tFPDF](https://github.com/DocnetUK/tfpdf) PDF library. Treat as read-only third-party code; excluded from linting.
 - `lang/` — translations and the `.pot` file.
 - `sensei-certificates-functions.php` — global template/helper functions.
-- `.github/` — PR and issue templates only; there are no CI workflows in this repo.
+- `changelog/` — per-PR changelog entries (created via `npm run changelog`; see Conventions).
+- `.github/` — PR and issue templates plus CI definitions.
 
 ## Sensei LMS dependency
 
@@ -49,18 +50,17 @@ Sensei LMS Certificates is a **runtime** extension of Sensei LMS — there is no
 - **Ad-hoc UI verification**: For UI or behavior changes, use the `ui-verification` skill (`.claude/skills/ui-verification/SKILL.md`), which scopes from the diff and drives the running site via Chrome DevTools MCP. Requires a WordPress install with Sensei LMS active and a course a student can complete.
 
 ## Linting
-- **PHPCS** (WordPress coding standards, config in `phpcs.xml.dist`): run `./vendor/bin/phpcs` after `composer install`. Auto-fix with `./vendor/bin/phpcbf`. `lib/`, `vendor/`, `node_modules/`, `build/`, and `tests/` are excluded. Enforced global prefixes are `sensei` and `woothemes`; text domain is `sensei-certificates`.
-- **JS**: `npm run lint:js` (ESLint via `wp-scripts` on `assets/js`). Format with `npm run format:js`.
-- **CSS/SCSS**: `npm run lint:css` (stylelint via `wp-scripts` on `assets/css`).
-- **package.json**: `npm run lint:pkg-json`.
-- There is no CI in this repo enforcing these, so run the relevant linters yourself before opening a PR.
+- **PHPCS**: Run `npm run lint:php`. Auto-fix with `npm run format:php`.
+- **JS / CSS / package.json**: `npm run lint:js` (ESLint on `assets/js`), `npm run lint:css` (stylelint on `assets/css`), `npm run lint:pkg-json` (package.json).
+- **Before pushing**: CI runs PHPCS on every PR. Always run `npm run lint:php` on modified files before pushing to avoid CI failures.
 
 ## Conventions
+- **Changelogs**: Every user-facing change MUST have a changelog entry. Add one with `npm run changelog` (fill Significance/Type/Message; writes the `changelog/` file). For purely internal changes (refactors, test-only), apply the `No Changelog` label instead.
+- **PR milestones**: Every PR should have a milestone. The `pull-request` skill assigns the next shipping milestone when it opens a PR.
 - **Coding standards**: Follow the WordPress coding standards for the language you touch — [PHP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/), [JavaScript](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/), [CSS](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/css/). Use long-form `array( ... )` in new PHP.
 - **Naming — local exceptions to Sensei's conventions**: Follow Sensei LMS's naming conventions (linked under "Read before writing code") for new code, except where this repo's established patterns win: classes are prefixed `WooThemes_Sensei_` / `Woothemes_Sensei_`, and globals (functions, hooks) use the `sensei` / `woothemes` prefixes enforced by `phpcs.xml.dist`. Existing `learner`-based identifiers and DB keys (e.g. the `learner_id` post meta) can't be renamed — leave them. Do not rewrite surrounding code to match a new style.
-- **Documenting hooks and functions**: Give new or changed actions/filters and public functions a docblock (params, return, `@since`). For `@since`, use the version being released (there is no `$$next-version$$` placeholder tooling in this repo). When deprecating code, name the replacement in the docblock.
+- **Documenting hooks and functions**: Document new or updated actions/filters and public functions with docblocks (params, return, `@since`). For `@since`, use the next version being released. When a change adds or updates a hook, describe it and apply the `Hooks` label; when it deprecates code, name the replacement and apply the `Deprecation` label.
 - **Minimum supported versions**: The `woothemes-sensei-certificates.php` plugin header is the source of truth — `Requires PHP` (minimum PHP) and `Requires at least` (minimum WordPress). Keep it, `readme.txt`, and `SENSEI_CERTIFICATES_VERSION` in sync on a version bump. Don't use PHP features newer than the minimum.
-- **Version bumps**: Keep the version in sync across `woothemes-sensei-certificates.php` (header + `SENSEI_CERTIFICATES_VERSION`), `package.json`, and `readme.txt` (`Stable tag`).
 
 ## Common pitfalls
 - **Editing the `sensei` source or `lib/tfpdf/` from this repo.** Both are effectively read-only here — fix Sensei LMS concerns upstream in `sensei`; treat tFPDF as vendored third-party code.


### PR DESCRIPTION
### Changes proposed in this Pull Request

The repo recently gained the Jetpack changelogger and a PHP-linting CI check, but AGENTS.md still claimed there was no CI and documented neither. This updates the guide so contributors know to add a changelog entry (`npm run changelog`) and that PHPCS now runs in CI. While there, it aligns the Linting, Changelog, PR-milestone, and hook-documentation guidance with Sensei LMS's AGENTS.md wording, links the vendored tFPDF upstream, and drops the release-only version-bump bullet.