### PR TITLE
Update PR template and pull-request skill

### DIFF
--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -14,8 +14,8 @@ description: >-
 
 # Open a Sensei LMS Certificates Pull Request
 
-Fill the repo's PR template from the diff, do the required chores (changelog,
-milestone), and stop for approval before `gh pr create` — which pushes the branch.
+Fill the repo's PR template from the diff, do the required chores in the steps
+below, and stop for approval before `gh pr create` — which pushes the branch.
 
 ## Who this is for
 
@@ -104,9 +104,9 @@ Fill each section from the diff. Guidance per section:
 ### 4. Changelog — a committed entry, not the PR body
 
 This repo uses Jetpack changelogger; entries live as files under `changelog/` and
-are rolled into `changelog.txt` on release. There is no CI to generate one, so the
-entry is a file you commit to the branch (or the PR carries the **No Changelog**
-label).
+are rolled into `changelog.txt` on release. CI lints PHP but does not generate the
+changelog, so the entry is a file you commit to the branch (or the PR carries the
+**No Changelog** label).
 
 First check whether the branch already has an entry — a dev may have run
 `npm run changelog` during development and committed it:

--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -2,20 +2,36 @@
 name: pull-request
 description: >-
   Open a GitHub pull request for the Sensei LMS Certificates plugin the way this
-  repo expects. Use this whenever the user wants to create, open, draft, or "put
+  repo requires. Use this whenever the user wants to create, open, draft, or "put
   up" a PR, or says things like "open a PR", "create a pull request", "make a PR
   for this branch", or "PR this". It fills the repo's PULL_REQUEST_TEMPLATE.md
-  from the actual diff against trunk and stops for approval before pushing.
-  Prefer this over a bare `gh pr create` so the body matches the template
-  reviewers expect and the PR gets its required milestone.
+  from the actual diff against trunk, commits the changelog entry (or applies the
+  No Changelog label), assigns the required milestone, and stops for approval
+  before pushing. Prefer this skill over a bare `gh pr create` so the PR carries
+  its changelog entry and milestone, and so the body matches the template
+  reviewers expect.
 ---
 
 # Open a Sensei LMS Certificates Pull Request
 
-Fill the repo's PR template from the diff and stop for approval before
-`gh pr create` — which pushes the branch.
+Fill the repo's PR template from the diff, do the required chores (changelog,
+milestone), and stop for approval before `gh pr create` — which pushes the branch.
 
-The repo is `woocommerce/sensei-certificates`. The base branch is `trunk`.
+## Who this is for
+
+This skill assumes **write access to `woocommerce/sensei-certificates`** — it
+assigns the milestone (needs triage/write permission). One step doesn't apply to
+fork / external contributors:
+
+- **Milestone:** external contributors can't assign one — leave it; a maintainer
+  sets the milestone on their side.
+
+Everything else (template body, changelog entry, testing instructions,
+stop-before-push) applies to everyone.
+
+## Base branch
+
+The base is always `trunk`. Compare against it, not `main`.
 
 ## Steps
 
@@ -27,7 +43,8 @@ The repo is `woocommerce/sensei-certificates`. The base branch is `trunk`.
 
 ### 2. Understand the change from the diff
 
-Describe what the diff does, not how you got there.
+Describe what the diff does, not how you got there — commit-by-commit narration
+is noise to a reviewer.
 
 ```bash
 git merge-base trunk HEAD          # fork point
@@ -37,50 +54,91 @@ git diff trunk...HEAD              # the actual change — read this
 ```
 
 Read the diff. From it, decide the **title** — one line, imperative, concise, no
-conventional-commit prefix (no `feat:` / `fix:`).
+conventional-commit prefix (no `feat:` / `fix:`). Example:
+`Add course link to quiz page breadcrumb`.
 
 ### 3. Fill the repo's PR template
 
-Read it and fill it in — don't invent your own headings:
+Do not invent your own headings. Read the template and fill it in:
 
 ```bash
 cat .github/PULL_REQUEST_TEMPLATE.md
 ```
 
-Per section:
+Fill each section from the diff. Guidance per section:
 
-- **`Fixes #`** — fill as `Fixes #<n>` if the user gave an issue number, or one
-  appears in the branch name or commit messages. If there's no issue, remove the
-  line — a bare `Fixes #` is noise. Never guess a number.
-- **`### Changes proposed in this Pull Request`** — the reviewer-facing summary.
-  Lead with the problem/need and the user impact, then the approach at a high
-  level. Don't re-list modified files or narrate implementation — the diff shows
-  that.
-- **`### Testing instructions`** — manual steps a reviewer follows to verify
-  (click paths, expected on-screen results, edge cases). For certificate changes
-  this usually means: complete a course as a student, then check the certificate
-  renders, downloads as a PDF, and the "View Certificate" link/block appears.
-  Never list running automated suites — there are none.
-- **`### New/Updated Hooks`** — fill only if the diff adds or changes an action or
+- **`Resolves #`** — fill it in as `Resolves #<n>` if the user gave an issue
+  number, or one appears in the branch name or the commit messages. If there's no
+  issue, **remove this line entirely** — a bare `Resolves #` is noise. Never guess
+  a number.
+- **`## Proposed Changes`** — the reviewer-facing summary. Lead with the
+  **problem or need** and the **user impact** (new capability, bug fixed,
+  performance, accessibility, behavior change or trade-off), then the approach at a
+  high level. Don't re-list the modified files or narrate implementation mechanics
+  — the diff already shows that; prose that just restates it wastes the reviewer's
+  time. If the change is user-visible, a reader should understand *what changes for
+  them* without opening the diff.
+- **`## Screenshots`** — keep this section only when the change is **visual**.
+  Judge that from the diff: it touches front-end/editor surfaces — `assets/`
+  (JS/CSS/SCSS), block markup, `render.php`, front-end templates, or editor
+  components. If it's not visual (pure PHP logic, REST, data, tooling, tests),
+  **remove this whole section**. When you keep it, leave the template's empty
+  Before/After table for the user to fill (for net-new UI with no "before" state,
+  replace it with a note to paste a single screenshot or short video). You cannot
+  capture the images yourself, so at the approval gate (step 5) remind the user to
+  attach them.
+- **`## Testing Instructions`** — a checkbox list (`- [ ] step`) of manual steps a
+  human follows to verify the change (click paths, expected on-screen results,
+  edge cases), so the reviewer can tick each as they test. **Never list running
+  automated suites as a step** — there are none; the reviewer verifies behavior by
+  hand. If the change has no manual surface (e.g. test-only or pure internal
+  refactor), say so briefly instead of padding with "run the tests".
+- **`## New/Updated Hooks`** — fill only if the diff adds or changes an action or
   filter; describe each and its args, and plan to add the **Hooks** label. If the
-  diff touches no hooks, remove this whole section from the body.
-- **`### Deprecated Code`** — fill only if the diff deprecates something; name the
-  replacement and plan to add the **Deprecation** label. Otherwise remove the
-  section.
-- **`### Screenshot / Video`** — keep only when the change is visual (touches
-  `assets/`, blocks, or `templates/`). You can't capture the images yourself, so
-  at the approval gate remind the user to attach them. If the change isn't visual,
-  remove the section.
+  diff touches no hooks, **remove this whole section** (heading, comment, and
+  placeholder) from the body rather than leaving an empty `*`.
+- **`## Deprecated Code`** — fill only if the diff deprecates something; name the
+  replacement and plan to add the **Deprecation** label. If nothing is deprecated,
+  **remove this whole section** from the body.
 
-### 4. Stop and confirm — this is the push gate
+### 4. Changelog — a committed entry, not the PR body
 
-Show the user the proposed **title** and the **filled template body** (call out any
-labels: Hooks / Deprecation). If you kept a Screenshot section, remind them to
-attach images. Wait for explicit approval. Do not run `gh pr create` until they
-say go — it pushes the branch and opens the PR, which is outward-facing and hard
-to walk back.
+This repo uses Jetpack changelogger; entries live as files under `changelog/` and
+are rolled into `changelog.txt` on release. There is no CI to generate one, so the
+entry is a file you commit to the branch (or the PR carries the **No Changelog**
+label).
 
-### 5. Create the PR
+First check whether the branch already has an entry — a dev may have run
+`npm run changelog` during development and committed it:
+
+```bash
+git diff --name-only --diff-filter=A trunk...HEAD -- changelog/
+```
+
+If that lists a file, the entry already exists — note it in the summary you show
+the user.
+
+- **User-facing change (no committed entry yet):** tell the user to run
+  `npm run changelog` and commit the new `changelog/` file with the PR — it's
+  interactive, so don't run it for them. Write the **Message** as the user-facing
+  outcome (one sentence — the effect, not the implementation). When the
+  significance is ambiguous (e.g. a `fix/` branch that repairs behavior but also
+  adds a small element), lean toward `Patch` / `Fixed` — match how the work is
+  framed rather than over-classifying it as a feature.
+- **Internal-only change** (refactor, test-only, tooling — no user-facing effect):
+  plan to apply the **`No Changelog`** label to the PR. Say this in the summary you
+  show the user.
+
+### 5. Stop and confirm — this is the push gate
+
+Show the user the proposed **title** and the **filled template body** (call out the
+changelog choice and any labels: Hooks / Deprecation / No Changelog). If you kept a
+**Screenshots** section, remind the user to attach before/after images — you can't
+capture them, and the placeholder ships empty otherwise. Then wait for explicit
+approval. Do not run `gh pr create` until they say go — it pushes the branch and
+opens the PR, which is outward-facing and hard to walk back.
+
+### 6. Create the PR
 
 After approval:
 
@@ -88,25 +146,23 @@ After approval:
 gh pr create --base trunk --title "<title>" --body "<filled template body>"
 ```
 
-`gh` pushes the current branch as part of this. Capture the PR number it prints,
-then apply any labels you flagged:
+`gh` pushes the current branch as part of this. Capture the PR number it prints.
+Apply any labels you flagged (e.g. `No Changelog`, `Hooks`, `Deprecation`):
 
 ```bash
-gh pr edit <PR_NUMBER> --add-label "Hooks"
+gh pr edit <PR_NUMBER> --add-label "No Changelog"
 ```
 
-### 6. Assign the milestone (required)
+### 7. Assign the milestone (required)
 
 Find the next shipping milestone (lowest-versioned open one) and assign it. Use
-`sort -V` — a plain sort mis-orders versions (e.g. `2.5.5` vs `2.10.0`):
+`sort -V` (version sort) — a plain string sort mis-orders `2.5.5` vs `2.10.0`:
 
 ```bash
 next=$(gh api 'repos/woocommerce/sensei-certificates/milestones?state=open' --jq '.[].title' | sort -V | head -1)
 gh pr edit <PR_NUMBER> --milestone "$next"
 ```
 
-If the user named a target release, use that milestone instead of the lowest.
-
-### 7. Wrap up
+### 8. Wrap up
 
 Give the user the PR URL.

--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -147,10 +147,12 @@ gh pr create --base trunk --title "<title>" --body "<filled template body>"
 ```
 
 `gh` pushes the current branch as part of this. Capture the PR number it prints.
-Apply any labels you flagged (e.g. `No Changelog`, `Hooks`, `Deprecation`):
+Apply any labels you flagged (e.g. `No Changelog`, `Hooks`, `Deprecation`), and
+assign the PR to its author (`@me` is the authenticated user opening it):
 
 ```bash
 gh pr edit <PR_NUMBER> --add-label "No Changelog"
+gh pr edit <PR_NUMBER> --add-assignee "@me"
 ```
 
 ### 7. Assign the milestone (required)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,25 +1,27 @@
-Fixes #
+Resolves #
 
-### Changes proposed in this Pull Request
-
+## Proposed Changes
 *
 
-### Testing instructions
+## Screenshots
+<!-- For visual changes, fill the Before/After table below. For net-new UI with no "before", drop the table and paste a single screenshot or short video. Remove this whole section if the change has no visual surface. -->
 
-*
+| Before | After |
+| --- | --- |
+|  |  |
 
+## Testing Instructions
+<!-- List the manual steps a reviewer follows to verify the change; they tick each as they test. Replace the placeholders below. -->
+
+- [ ] Step 1
+- [ ] Step 2
+
+## New/Updated Hooks
 <!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
-### New/Updated Hooks
 
 *
 
+## Deprecated Code
 <!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
-### Deprecated Code
 
 *
-
-<!--
-Helpful tips for screenshots:
-https://en.support.wordpress.com/make-a-screenshot/
--->
-### Screenshot / Video


### PR DESCRIPTION
## Proposed Changes
Brings this repo's PR workflow in line with the main sensei repo:

- **PR template** — replaces the old free-form template with Sensei LMS's structure (Proposed Changes, Screenshots with a Before/After table, checkbox Testing Instructions, Hooks, Deprecated Code). The changelog-entry section from Sensei's template is omitted: it exists there to have CI auto-generate the entry, and this repo's CI only lints PHP — the changelog is written locally via `npm run changelog` instead.
- **`pull-request` skill** — updated to match Sensei's wording and section headings, diverging only where facts/commands differ here: `npm run changelog` instead of `make changelog`, the changelog entry is a committed file rather than CI-generated, and the PR is self-assigned to its author.