### PR TITLE
Migrate View Certificate Link block to Block API version 3

### DIFF
--- a/assets/blocks/view-certificate-link/block.json
+++ b/assets/blocks/view-certificate-link/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "sensei-certificates/view-certificate-link",
 	"title": "View Certificate",
 	"category": "sensei-lms",

--- a/changelog/fix-view-certificate-block-api-v3
+++ b/changelog/fix-view-certificate-block-api-v3
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Migrate the View Certificate Link block to Block API version 3.


### PR DESCRIPTION
## Proposed Changes

The View Certificate Link block was registered with Block API version 2. WordPress 6.9 deprecates v2/lower and logs a console warning in the editor; all editors are moving to iframe-only rendering, where v2 blocks aren't guaranteed to work. This bumps the block to API version 3.

No behavior change: the edit component already uses `useBlockProps` and the server render already uses `get_block_wrapper_attributes()`, so the block was v3-ready — only the declared `apiVersion` needed updating. Built assets regenerated.

## Testing Instructions

- [x] Hard-reload the editor (bust cached assets) and open the browser console.
- [x] Edit the Course Completed page which should have a View Certificate block on it.
- [x] Confirm no `Block with API version 2 or lower is deprecated` warning appears for `sensei-certificates/view-certificate-link`.
- [x] Confirm the block still renders the "View Certificate" placeholder link in the editor.
- [x] As a student who completed a course with a certificate template, confirm the front-end link shows and points to the certificate.
- [x] As a user without completion/template, confirm no link renders.