### PR TITLE
Fix missing and untranslated strings in the block editor

### DIFF
--- a/assets/blocks/index.js
+++ b/assets/blocks/index.js
@@ -25,7 +25,7 @@ registerBlockVariation( 'core/button', {
 		'Enable students to view their course certificate.',
 		'sensei-certificates'
 	),
-	keywords: [ __( 'Certificates', 'sensei-lms' ) ],
+	keywords: [ __( 'Certificates', 'sensei-certificates' ) ],
 	category: 'sensei-lms',
 	attributes,
 	isActive: ( blockAttributes, variationAttributes ) =>

--- a/changelog/fix-359-block-editor-translations
+++ b/changelog/fix-359-block-editor-translations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix missing and untranslated strings in the block editor.

--- a/classes/class-woothemes-sensei-certificates.php
+++ b/classes/class-woothemes-sensei-certificates.php
@@ -174,7 +174,7 @@ class WooThemes_Sensei_Certificates {
 		self::load_files();
 
 		if ( class_exists( 'Sensei_Assets' ) ) {
-			$instance->assets = new \Sensei_Assets( $instance->plugin_url, dirname( __DIR__ ), SENSEI_CERTIFICATES_VERSION );
+			$instance->assets = new \Sensei_Assets( $instance->plugin_url, dirname( __DIR__ ), SENSEI_CERTIFICATES_VERSION, 'sensei-certificates' );
 		}
 
 		// Load blocks.

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "lint:pkg-json": "wp-scripts lint-pkg-json",
     "packages-update": "wp-scripts packages-update",
     "start": "wp-scripts start",
-    "i18n:build": "npm run i18n:php",
-    "i18n:php": "wp i18n make-pot --exclude=lib,vendor,node_modules --skip-js --headers='{\"Last-Translator\":null,\"Language-Team\":null,\"Report-Msgid-Bugs-To\":\"https://wordpress.org/support/plugin/sensei-certificates\"}' . lang/sensei-certificates.pot"
+    "i18n:build": "npm run build:assets && npm run i18n:pot",
+    "i18n:pot": "wp i18n make-pot --exclude=lib,vendor,node_modules --headers='{\"Last-Translator\":null,\"Language-Team\":null,\"Report-Msgid-Bugs-To\":\"https://wordpress.org/support/plugin/sensei-certificates\"}' . lang/sensei-certificates.pot"
   },
   "config": {
     "wp_org_slug": "sensei-certificates"


### PR DESCRIPTION
Resolves #359

## Proposed Changes

Block editor strings for the View Certificate block were shipping either missing from the translation template or untranslated at runtime. Two causes:

- The plugin's `Sensei_Assets` instance was created without a text domain, so it defaulted to `sensei-lms`. `wp_set_script_translations()` then looked up the editor script's translations under the wrong domain and never found them, leaving strings like "View Certificate" untranslated.
- The POT-generation script ran `make-pot` with `--skip-js`, so JS strings (e.g. "Enable students to view their course certificate." and "A Buttons block with a View Certificate button.") were never extracted and had nothing to translate against.

This passes `sensei-certificates` as the asset text domain, drops `--skip-js`, and builds assets before extraction so the POT carries the dist references the runtime JSON files are keyed on. Also corrects one keyword string that was tagged with the `sensei-lms` domain instead of `sensei-certificates`.

## Testing Instructions

- [x] Run `npm run i18n:build` so the JS strings and their `assets/dist/blocks/index.js` references are in `lang/sensei-certificates.pot`.
- [x] Install and activate [Loco Translate](https://wordpress.org/plugins/loco-translate/) (`wp plugin install loco-translate --activate`).
- [x] In wp-admin, go to Loco Translate → Plugins → Sensei LMS Certificates, add a new language, and enter obvious fake translations for "View Certificate", "Enable students to view their course certificate.", and "A Buttons block with a View Certificate button.", then Save. Loco writes the `.mo` and the JS `.json` files automatically.
- [x] Switch the site language (Settings → General → Site Language) to that language.
- [x] Open the Course Completed page in the editor and confirm the View Certificate block's title, description, and inserter strings render translated.