### PR TITLE
Add changelogger release tooling and migrate changelog.txt to Keep-A-Changelog

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,184 +1,174 @@
 *** Changelog ***
 
-2025.12.15 - version 2.5.4
-* Fix: PHP 8.2 utf8_decode deprecation notice - #369
+## 2.5.4 - 2025-12-15
+- Fix: PHP 8.2 utf8_decode deprecation notice. [#369](https://github.com/woocommerce/sensei-certificates/pull/369)
 
+## 2.5.3 - 2024-11-14
+- Fix: Adjust the template check for the Certificate Template preview. [#362](https://github.com/woocommerce/sensei-certificates/pull/362)
 
-2024.11.14 - version 2.5.3
-* Fix: Adjust the template check for the Certificate Template preview - #362
+## 2.5.2 - 2024-08-08
+- New: Add certificate data field hooks. [#292](https://github.com/woocommerce/sensei-certificates/pull/292)
+- Fix: Allow certificates to be removed from a course. [#353](https://github.com/woocommerce/sensei-certificates/pull/353)
+- Fix: Certificates not rendering on PHP 8.2. [#354](https://github.com/woocommerce/sensei-certificates/pull/354)
 
-2024.08.08 - version 2.5.2
-* New: Add certificate data field hooks - #292
-* Fix: Allow certificates to be removed from a course - #353
-* Fix: Certificates not rendering on PHP 8.2 - #354
+## 2.5.1 - 2023-09-19
+- Fix: Missing "View Certificate" link for `sensei_user_courses` shortcode. [#348](https://github.com/woocommerce/sensei-certificates/pull/348)
 
-2023.09.19 - version 2.5.1
-Fix: Missing "View Certificate" link for `sensei_user_courses` shortcode - #348
+## 2.5.0 - 2023-08-24
+- New: Display View Certificate button on public learner profile. [#341](https://github.com/woocommerce/sensei-certificates/pull/341)
+- Fix: Deprecation notice for creation of dynamic property. [#343](https://github.com/woocommerce/sensei-certificates/pull/343)
 
-2023.08.24 - version 2.5.0
-* New: Display View Certificate button on public learner profile - #341
-* Fix: Deprecation notice for creation of dynamic property - #343
+## 2.4.0 - 2023-06-01
+- New: Add "View Certificate" link to Course List templates. [#327](https://github.com/woocommerce/sensei-certificates/pull/327)
+- New: Bump minimum PHP version to 7.2.
+- Fix: Error on the certificate page for WP VIP users. [#335](https://github.com/woocommerce/sensei-certificates/pull/335)
+- Fix: Report links on the certificates listing. [#298](https://github.com/woocommerce/sensei-certificates/pull/298)
+- Fix: Deprecated function warning. [#336](https://github.com/woocommerce/sensei-certificates/pull/336)
 
-2023.06.01 - version 2.4.0
-* New: Add "View Certificate" link to Course List templates - #327
-* New: Bump minimum PHP version to 7.2
-* Fix: Error on the certificate page for WP VIP users - #335
-* Fix: Report links on the certificates listing - #298
-* Fix: Deprecated function warning - #336
+## 2.3.0 - 2022-07-11
+- New: Add View Certificate block. [#302](https://github.com/woocommerce/sensei-certificates/pull/302)
+- New: Bump minimum PHP version to 7.0. [#293](https://github.com/woocommerce/sensei-certificates/pull/293)
+- New: Add setting to delete data on uninstall. [#291](https://github.com/woocommerce/sensei-certificates/pull/291)
+- Fix: Redirect to login when viewing a certificate as a guest. [#289](https://github.com/woocommerce/sensei-certificates/pull/289)
+- Fix: Fix warning when accessing certificate. [#299](https://github.com/woocommerce/sensei-certificates/pull/299)
 
-2022.07.11 - version 2.3.0
-* New: Add View Certificate block - #302
-* New: Bump minimum PHP version to 7.0 - #293
-* New: Add setting to delete data on uninstall - #291
-* Fix: Redirect to login when viewing a certificate as a guest - #289
-* Fix: Fix warning when accessing certificate - #299
+## 2.2.1 - 2021-08-27
+- Tweak: Add View Certificate button to the Course Completed page automatically. [#280](https://github.com/woocommerce/sensei-certificates/pull/280)
+- Fix: Don't display View Certificate button if course has no certificate template. [#277](https://github.com/woocommerce/sensei-certificates/pull/277)
 
-2021.08.27 - version 2.2.1
-* Tweak: Add View Certificate button to the Course Completed page automatically - #280
-* Fix: Don't display View Certificate button if course has no certificate template - #277
+## 2.2.0 - 2021-08-12
+- New: Add "View Certificate" button to Course Completed Actions block. [#271](https://github.com/woocommerce/sensei-certificates/pull/271)
 
-2021.08.12 - version 2.2.0
-* New: Add "View Certificate" button to Course Completed Actions block - #271
+## 2.1.0 - 2021-03-02
+- New: Introduce new tools to replace data updates. [#254](https://github.com/woocommerce/sensei-certificates/pull/254)
+- Tweak: Update tFPDF version. [#149](https://github.com/woocommerce/sensei-certificates/pull/149), [#256](https://github.com/woocommerce/sensei-certificates/pull/256)
 
-2021.03.02 - version 2.1.0
-* New: Introduce new tools to replace data updates - #254
-* Tweak: Update tFPDF version - #149, #256
+## 2.0.7 - 2020-10-27
+- Tweak: Remove JS code that references non-existent selectors. [#247](https://github.com/woocommerce/sensei-certificates/pull/247)
+- Tweak: Switch to webpack via wordpress-scripts and simplify build. [#241](https://github.com/woocommerce/sensei-certificates/pull/241)
+- Tweak: Add missing translator comments. [#248](https://github.com/woocommerce/sensei-certificates/pull/248)
+- Fix: Don't encode course title for HTML display in PDF generation. [#243](https://github.com/woocommerce/sensei-certificates/pull/243)
 
-2020.10.27 - version 2.0.7
-* Tweak: Remove JS code that references non-existent selectors - #247
-* Tweak: Switch to webpack via wordpress-scripts and simplify build - #241
-* Tweak: Add missing translator comments - #248
-* Fix: Don't encode course title for HTML display in PDF generation - #243
+## 2.0.6 - 2020-08-21
+- Fix: Allow line breaks in certificate templates. [#239](https://github.com/woocommerce/sensei-certificates/pull/239)
+- Fix: Fix certificate template image functionality. [#238](https://github.com/woocommerce/sensei-certificates/pull/238)
 
-2020.08.21 - version 2.0.6
-* Fix: Allow line breaks in certificate templates - #239
-* Fix: Fix certificate template image functionality - #238
+## 2.0.5 - 2020-07-20
+- New: Add German translation. [#214](https://github.com/woocommerce/sensei-certificates/pull/214)
+- Fix: Fix dropdown in Certificate Template meta box. [#225](https://github.com/woocommerce/sensei-certificates/pull/225)
 
-2020.07.20 - version 2.0.5
-* New: Add German translation - #214
-* Fix: Fix dropdown in Certificate Template meta box - #225
+## 2.0.4 - 2020-04-27
+- Fix: Fix issues reported by PHPCS. [#219](https://github.com/woocommerce/sensei-certificates/pull/219)
 
-2020.04.27 - version 2.0.4
-* Fix: Fix issues reported by PHPCS - #219
+## 2.0.3 - 2020-04-16
+- New: Prepare the plugin to be distributed through WordPress.org. [#215](https://github.com/woocommerce/sensei-certificates/pull/215)
 
-2020.04.16 - version 2.0.3
-* New: Prepare the plugin to be distributed through WordPress.org - #215
+## 2.0.2 - 2020-03-20
+- Fix: Certificate display issue when using non-Latin characters. [#211](https://github.com/woocommerce/sensei-certificates/pull/211)
 
-2020.03.20 - version 2.0.2
-* Fix: Certificate display issue when using non-Latin characters - #211
+## 2.0.1 - 2020-03-12
+- New: Rename plugin to Sensei LMS Certificates. [#195](https://github.com/woocommerce/sensei-certificates/pull/195)
+- Tweak: Remove certificates and templates from public search queries. [#183](https://github.com/woocommerce/sensei-certificates/pull/183)
+- Tweak: Retrieve absolute image path via get_attached_file. [#199](https://github.com/woocommerce/sensei-certificates/pull/199)
+- Tweak: Only load CSS on pages that require it. [#205](https://github.com/woocommerce/sensei-certificates/pull/205)
+- Tweak: Replace use of deprecated course_query function. [#207](https://github.com/woocommerce/sensei-certificates/pull/207)
+- Fix: Ensure font files can be accessed when plugin is copied to another site. [#193](https://github.com/woocommerce/sensei-certificates/pull/193)
+- Fix: Localize placeholder text when editing certificate template. [#206](https://github.com/woocommerce/sensei-certificates/pull/206)
+- Fix: Don't hide template positioning box when clicking off it. [#204](https://github.com/woocommerce/sensei-certificates/pull/204)
 
-2020.03.12 - version 2.0.1
-* New: Rename plugin to Sensei LMS Certificates - #195
-* Tweak: Remove certificates and templates from public search queries - #183
-* Tweak: Retrieve absolute image path via get_attached_file - #199
-* Tweak: Only load CSS on pages that require it - #205
-* Tweak: Replace use of deprecated course_query function - #207
-* Fix: Ensure font files can be accessed when plugin is copied to another site - #193
-* Fix: Localize placeholder text when editing certificate template - #206
-* Fix: Don't hide template positioning box when clicking off it - #204
+## 2.0.0 - 2019-04-25
+- New: Add dependency check for minimum Sensei (1.11.0) and PHP (5.6) versions. [#171](https://github.com/woocommerce/sensei-certificates/pull/171)
+- New: Add certificate link to course completion emails. [#174](https://github.com/woocommerce/sensei-certificates/pull/174)
+- New: Add Hungarian translation (@amroland). [#170](https://github.com/woocommerce/sensei-certificates/pull/170), [#177](https://github.com/woocommerce/sensei-certificates/pull/177)
+- Tweak: Check dependencies and perform the majority of plugin loading tasks after other plugins have loaded. [#175](https://github.com/woocommerce/sensei-certificates/pull/175)
+- Tweak: Use Woo header for plugin updates. [#172](https://github.com/woocommerce/sensei-certificates/pull/172)
+- Fix: Disable viewing of certificates for courses without a certificate template. [#173](https://github.com/woocommerce/sensei-certificates/pull/173)
 
-2019.04.25 - version 2.0.0
-* New: Add dependency check for minimum Sensei (1.11.0) and PHP (5.6) versions - #171
-* New: Add certificate link to course completion emails - #174
-* New: Add Hungarian translation (@amroland) - #170, #177
-* Tweak: Check dependencies and perform the majority of plugin loading tasks after other plugins have loaded - #175
-* Tweak: Use Woo header for plugin updates - #172
-* Fix: Disable viewing of certificates for courses without a certificate template - #173
+## 1.1.1 - 2018-12-06
+- Fixes JavaScript error when editing a certificate template.
+- Adds additional string escaping throughout the plugin.
+- Fixes minor issue with restoring trashed certificate templates.
+- Add translations for Russian and French.
 
-2018.12.06 - version 1.1.1
-* Fixes JavaScript error when editing a certificate template
-* Adds additional string escaping throughout the plugin
-* Fixes minor issue with restoring trashed certificate templates
-* Add translations for Russian and French
+## 1.1.0 - 2018-07-23
+- Make date formatting for certificates follow the WP date format by default.
+- Fix certificates menu position for Teacher users.
 
-2018.07.23 - version 1.1.0
-* Make date formatting for certificates follow the WP date format by default
-* Fix certificates menu position for Teacher users
+## 1.0.17 - 2017-11-01
+- Fix fatal on plugin activation.
+- Remove unnecessary .pot file.
+- Make placeholders translatable in post_type_setup.
 
-2017.11.01 - version 1.0.17
-* Fix fatal on plugin activation
-* Remove unnecessary .pot file
-* Make placeholders translatable in post_type_setup
+## 1.0.16 - 2017-05-03
+- Fix fatal when activating certificates for the first time.
 
-2017.05.03 - version 1.0.16
-* Fix fatal when activating certificates for the first time
+## 1.0.15 - 2017-04-28
+- Admin: Allow only teachers and administrators to view admin areas.
+- Never bundle generated ttf specs from tfpdf.
 
-2017.04.28 - version 1.0.15
-* Admin: Allow only teachers and administrators to view admin areas
-* Never bundle generated ttf specs from tfpdf
+## 1.0.14 - 2017-04-25
+- Fix certificate data update.
+- Add the Display Name to the admin list table for certificates enhancement.
+- Fix Errors when previewing a certificate template bug.
+- Fix the selected admin menu item when editing a certificate template.
+- Fix Permissions error on certificate learner and course links bug.
+- Fix PHP 7 Errors/Notices on tfpdf.
 
-2017.04.25 - version 1.0.14
-* Fix certificate data update
-* Add the Display Name to the admin list table for certificates enhancement
-* Fix Errors when previewing a certificate template bug
-* Fix the selected admin menu item when editing a certificate template
-* Fix Permissions error on certificate learner and course links bug
-* Fix PHP 7 Errors/Notices on tfpdf
+## 1.0.13 - 2016-04-29
+- Fix: Fixed a deprecated function notice.
+- Fix: Ensures the certificate background image displays after saving template.
 
-2016.04.29 - version 1.0.13
- * Fix - Fixed a deprecated function notice
- * Fix - Ensures the certificate background image displays after saving template
+## 1.0.12 - 2016-02-02
+- Fix: Ensures certificates can be viewed when set to public.
+- Fix: Fixed a notice on certificates where background image id was not found.
+- Fix: Fixed a display issue with the certificate template dropdown.
+- Tweak: Ensure compatibility with Sensei 1.9.
 
-2016.02.02 - version 1.0.12
- * Fix - Ensures certificates can be viewed when set to public
- * Fix - Fixed a notice on certificates where background image id was not found
- * Fix - Fixed a display issue with the certificate template dropdown
- * Tweak - Ensure compatibility with Sensei 1.9
+## 1.0.11 - 2015-06-18
+- Fix: Ensure that the certificate view setting can only be seen by the current logged in user.
+- Tweak: Moved the certificates menu items to their own top level menu.
 
-2015.06.18 - version 1.0.11
- * Fix - Ensure that the certificate view setting can only be seen by the current logged in user
- * Tweak - Moved the certificates menu items to their own top level menu
+## 1.0.10 - 2015-06-11
+- Fix: Fix the certificate error that occurred when doing manual grading.
 
-2015.06.11 - version 1.0.10
- * Fix - Fix the certificate error that occurred when doing manual grading
+## 1.0.9 - 2015-02-10
+- Fix: Fixing certificate generation.
 
-2015.02.10 - version 1.0.9
- * Fix - Fixing certificate generation
+## 1.0.8 - 2015-02-01
+- Tweak: Updating code for Sensei 1.7 compatibility.
 
-2015.02.01 - version 1.0.8
- * Tweak - Updating code for Sensei 1.7 compatibility
+## 1.0.7 - 2014-09-23
+- Fix: Visit plugin site link in admin dashboard 404.
+- Fix: Fixed certificate orientation if background image is portrait.
+- Fix: Fixed a form display issue in the template editor.
+- Fix: Removing erroneous Select2 reference.
+- Tweak: If first and last name are added, they will be displayed on the certificate instead of the display name.
 
-2014.09.23 - version 1.0.7
- * Fix - Visit plugin site link in admin dashboard 404.
- * Fix - Fixed certificate orientation if background image is portrait.
- * Fix - Fixed a form display issue in the template editor.
- * Fix - Removing erroneous Select2 reference.
- * Tweak - If first and last name are added, they will be displayed on the certificate instead of the display name.
+## 1.0.6 - 2014-09-16
+- Fix: Ensures sensei_certificate_date_format filter applies to all certificates, not just previews.
+- Fix: Fixed coding standards warnings.
 
-2014.09.16 - version 1.0.6
- * Fix - Ensures sensei_certificate_date_format filter applies to all certificates, not just previews.
- * Fix - Fixed coding standards warnings.
+## 1.0.5 - 2014-06-23
+- Fix: Localizes completion date string to use correct language for month names.
+- Fix: Fixes PHP warning when a certificate template has no styles selected.
+- Fix: Ensures certificate link displays even if the course has no quizzes (requires Sensei v1.6).
 
-2014.06.23 - version 1.0.5
- * Fix - Localizes completion date string to use correct language for month names.
- * Fix - Fixes PHP warning when a certificate template has no styles selected.
- * Fix - Ensures certificate link displays even if the course has no quizzes (requires Sensei v1.6)
+## 1.0.4 - 2014-04-28
+- Update: Adding support for user-defined custom fonts.
+- Fix: Switching to tFPDF library for PDF generation to handle multibyte character sets (Greek, Arabic, etc.).
+- Fix: Making 'View Certificate' link text available for localization.
+- Fix: Hiding 'View Certificate' link if no certificate template is selected for the course.
 
-2014.04.28 - version 1.0.4
- * Update - Adding support for user-defined custom fonts
- * Fix - Switching to tFPDF library for PDF generation to handle multibyte character sets (Greek, Arabic, etc.)
- * Fix - Making 'View Certificate' link text available for localization
- * Fix - Hiding 'View Certificate' link if no certificate template is selected for the course
+## 1.0.3 - 2014-03-04
+- Fix: Switching background image to use path instead of URL.
 
-2014.03.04 - version 1.0.3
- * Fix - Switching background image to use path instead of URL
-   /classes/class-woothemes-sensei-certificates.php
+## 1.0.2 - 2014-01-14
+- Fix: Removes unnecessary rewrite endpoints, in favour of template_redirect.
+- Fix: Optimise the functionality to control access to, and to generate the certificate.
+- Fix: Ensure the extension doesn't break if a WooCommerce extension is activated.
 
-2014.01.14 - version 1.0.2
- * Fix - Removes unnecessary rewrite endpoints, in favour of template_redirect.
-   /classes/class-woothemes-sensei-certificates.php
+## 1.0.1 - 2013-12-12
+- Localization fixes.
 
- * Fix - Optimise the functionality to control access to, and to generate the certificate.
-   /classes/class-woothemes-sensei-certificates.php
-
- * Fix - Ensure the extension doesn't break if a WooCommerce extension is activated.
-   /woo-includes/woo-functions.php
-   /woo-includes/class-wc-dependencies.php
-
-2013.12.12 - version 1.0.1
- * /classes/class-woothemes-sensei-certificate-templates.php - Localization fix
- * /classes/class-woothemes-sensei-certificates.php - Localization fix
- * /woothemes-sensei-certificates.php - Localization fix
-
-2013.12.12 - version 1.0.0
- * First release
+## 1.0.0 - 2013-12-12
+- First release.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "build": "npm run build:assets && npm run archive",
     "build:assets": "wp-scripts build",
     "changelog": "vendor/bin/changelogger add",
+    "changelog:write": "vendor/bin/changelogger write --add-pr-num && ./scripts/changelog-unwrap-pr-links.sh",
     "archive": "composer archive --file=$npm_package_name --format=zip",
     "postarchive": "rm -rf $npm_package_name && unzip $npm_package_name.zip -d $npm_package_name && rm $npm_package_name.zip && zip -r $npm_package_name.zip $npm_package_name && rm -rf $npm_package_name",
     "check-engines": "wp-scripts check-engines",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build": "npm run build:assets && npm run archive",
     "build:assets": "wp-scripts build",
     "changelog": "vendor/bin/changelogger add",
-    "changelog:write": "vendor/bin/changelogger write --add-pr-num && ./scripts/changelog-unwrap-pr-links.sh",
+    "changelog:write": "vendor/bin/changelogger write --add-pr-num && bash ./scripts/changelog-unwrap-pr-links.sh",
     "archive": "composer archive --file=$npm_package_name --format=zip",
     "postarchive": "rm -rf $npm_package_name && unzip $npm_package_name.zip -d $npm_package_name && rm $npm_package_name.zip && zip -r $npm_package_name.zip $npm_package_name && rm -rf $npm_package_name",
     "check-engines": "wp-scripts check-engines",

--- a/scripts/changelog-unwrap-pr-links.sh
+++ b/scripts/changelog-unwrap-pr-links.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Turns the "[#123]" PR references that `changelogger write --add-pr-num`
+# appends to changelog.txt into Markdown links to the GitHub pull request.
+
+# Exit on error and output commands.
+set -ex
+
+CURRENT_DIR=$(pwd)
+OS_TYPE=$(uname -s)
+# sed arguments in different OS passed a bit differently.
+if [[ "$OS_TYPE" == "Darwin" ]]; then
+	sed -E -i '' "s/^.* \[#([0-9]+)\]$/&(https:\/\/github.com\/woocommerce\/sensei-certificates\/pull\/\\1)/" "$CURRENT_DIR/changelog.txt"
+elif [[ "$OS_TYPE" == "Linux" ]]; then
+	# You are on Linux
+	sed -E -i'' "s/^.* \[#([0-9]+)\]$/&(https:\/\/github.com\/woocommerce\/sensei-certificates\/pull\/\\1)/" "$CURRENT_DIR/changelog.txt"
+else
+    echo "Unsupported operating system"
+fi

--- a/scripts/changelog-unwrap-pr-links.sh
+++ b/scripts/changelog-unwrap-pr-links.sh
@@ -8,12 +8,13 @@ set -ex
 
 CURRENT_DIR=$(pwd)
 OS_TYPE=$(uname -s)
-# sed arguments in different OS passed a bit differently.
+# sed arguments are passed a bit differently on different operating systems.
 if [[ "$OS_TYPE" == "Darwin" ]]; then
 	sed -E -i '' "s/^.* \[#([0-9]+)\]$/&(https:\/\/github.com\/woocommerce\/sensei-certificates\/pull\/\\1)/" "$CURRENT_DIR/changelog.txt"
 elif [[ "$OS_TYPE" == "Linux" ]]; then
 	# You are on Linux
 	sed -E -i'' "s/^.* \[#([0-9]+)\]$/&(https:\/\/github.com\/woocommerce\/sensei-certificates\/pull\/\\1)/" "$CURRENT_DIR/changelog.txt"
 else
-    echo "Unsupported operating system"
+	echo "Unsupported operating system: $OS_TYPE" >&2
+	exit 1
 fi


### PR DESCRIPTION
## Proposed Changes

Ports Sensei LMS's `changelog-unwrap-pr-links.sh` (repointed at `woocommerce/sensei-certificates`) and adds a `changelog:write` npm script that runs `changelogger write --add-pr-num` then unwraps the appended `[#NNN]` refs into Markdown links.

Also migrates `changelog.txt` to the Keep-A-Changelog format changelogger expects (`## X.Y.Z - YYYY-MM-DD` headers, PR refs as Markdown links). The existing legacy format was unparseable, so `changelogger write` rolled in nothing; without this migration the tooling is inert. Historical wording is preserved.

## Testing Instructions

- [x] With at least one entry file under `changelog/`, run `npm run changelog:write`
- [x] Confirm entries roll into `changelog.txt` under a new `## X.Y.Z - <date>` version, each `[#NNN]` rendered as `[#NNN](https://github.com/woocommerce/sensei-certificates/pull/NNN)`
- [x] Confirm `vendor/bin/changelogger validate` exits cleanly against the migrated `changelog.txt`